### PR TITLE
👷 Add enforce-labels workflow

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,24 @@
+name: Enforce labels
+
+on:
+  pull_request_target:
+    types: [ opened, labeled, unlabeled, synchronize ]
+
+jobs:
+  enforce-labels:
+    name: Enforce pull request labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: "*"
+          use_regex: true
+          add_comment: true
+          message: "You need to assign at least one label before merging this pull request."


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce labeling on pull requests. The main changes include setting up the workflow to trigger on specific pull request events and defining a job to ensure at least one label is assigned before merging.

Enforcement of pull request labels:

* [`.github/workflows/enforce-labels.yml`](diffhunk://#diff-2485d8a92f727307678505865afb57a449b82f74d1a95c3df0411e33bca73901R1-R24): Added a new workflow configuration to enforce labeling on pull requests. The workflow triggers on `opened`, `labeled`, `unlabeled`, and `synchronize` events, and uses the `mheap/github-action-required-labels` action to ensure at least one label is assigned before merging.