### PR TITLE
👷 Add workflow dispatch trigger to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch: 
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration to enable manual triggering of the workflow.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R7): Added the `workflow_dispatch` event to the `on:` section to allow the workflow to be manually triggered.