### PR TITLE
👷 Add find and replace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,23 +59,31 @@ jobs:
       - name: Build App Bundle
         working-directory: app
         run: flutter build appbundle --release
-
+      
+      - name: Prepare version name
+        uses: step-security/actions-find-and-replace@v5
+        id: version_name
+        with:
+          source: ${{ github.ref_name }}
+          find: '/'
+          replace: '-'
+        
       - name: Rename APK & App Bundle
         working-directory: app
         run: |
-          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
-          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: app/build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
+          path: app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: release-appbundle
-          path: app/build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
+          path: app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
 
       - name: Release Artifacts
         if: startsWith(github.ref, 'refs/tags/')
@@ -83,5 +91,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            app/build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
-            app/build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
+            app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
+            app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         run: flutter build appbundle --release
       
       - name: Prepare version name
-        uses: step-security/actions-find-and-replace@v5
+        uses: step-security/actions-find-and-replace-string@v5
         id: version_name
         with:
           source: ${{ github.ref_name }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and releasing the app. It introduces a new step to prepare a sanitized version name and updates subsequent steps to use this version name instead of the raw branch or tag name.

### Workflow improvements:

* **Added a step to sanitize version names:**
  A new step, `Prepare version name`, was added to replace slashes (`/`) in the branch or tag name with dashes (`-`) using the `step-security/actions-find-and-replace` action. This ensures compatibility with file naming conventions. (`[.github/workflows/build.ymlR63-R95](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R63-R95)`)

* **Updated file naming to use sanitized version names:**
  The APK and App Bundle file names now use the sanitized version name (`steps.version_name.outputs.value`) instead of the raw `github.ref_name`. This change applies to renaming, uploading, and releasing artifacts. (`[.github/workflows/build.ymlR63-R95](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R63-R95)`)