### PR TITLE
Merge main into feature/home-screen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch: 
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,23 +59,31 @@ jobs:
       - name: Build App Bundle
         working-directory: app
         run: flutter build appbundle --release
-
+      
+      - name: Prepare version name
+        uses: step-security/actions-find-and-replace-string@v5
+        id: version_name
+        with:
+          source: ${{ github.ref_name }}
+          find: '/'
+          replace: '-'
+        
       - name: Rename APK & App Bundle
         working-directory: app
         run: |
-          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
-          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: app/build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
+          path: app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: release-appbundle
-          path: app/build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
+          path: app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
 
       - name: Release Artifacts
         if: startsWith(github.ref, 'refs/tags/')
@@ -83,5 +91,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            app/build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
-            app/build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
+            app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
+            app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip


### PR DESCRIPTION
This pull request updates the `.github/workflows/build.yml` file to improve the handling of version names in the GitHub Actions workflow. The changes involve introducing a step to sanitize the version name and updating subsequent steps to use the sanitized version name.

### Workflow improvements:

* **Added a step to sanitize the version name**: Introduced a new step, `Prepare version name`, using the `step-security/actions-find-and-replace-string@v5` action to replace slashes (`/`) in the `github.ref_name` with hyphens (`-`). This ensures compatibility in file naming.
* **Updated file renaming and artifact paths**: Modified the `Rename APK & App Bundle`, `Upload APK`, `Upload App Bundle`, and `Release Artifacts` steps to use the sanitized version name (`steps.version_name.outputs.value`) instead of the raw `github.ref_name`. This ensures consistency across the workflow.