### PR TITLE
👷 Add working rename job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Prepare version name
         id: version_name
         run: |
-          VERSION_NAME=$(echo "${{ github.ref_name }}" | tr '/' '-')
+          REF_NAME="${{ github.ref_name || github.ref }}"
+          VERSION_NAME="${REF_NAME#refs/*/}"
+          VERSION_NAME="${VERSION_NAME//\//-}"
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
         
       - name: Rename APK & App Bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,9 +64,9 @@ jobs:
         id: version_name
         run: |
           REF_NAME="${{ github.ref_name || github.ref }}"
-          VERSION_NAME="${REF_NAME#refs/*/}"
-          VERSION_NAME="${VERSION_NAME//\//-}"
-          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "${{ github.ref_name }}"
+          echo "${{ github.ref }}"
+          echo "version_name=REF_NAME" | tr / _ >> $GITHUB_OUTPUT
         
       - name: Rename APK & App Bundle
         working-directory: app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,10 @@ jobs:
         run: flutter build appbundle --release
       
       - name: Prepare version name
-        uses: step-security/actions-find-and-replace-string@v5
         id: version_name
-        with:
-          source: ${{ github.ref_name }}
-          find: '/'
-          replace: '-'
+        run: |
+          VERSION_NAME=$(echo "${{ github.ref_name }}" | tr '/' '-')
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
         
       - name: Rename APK & App Bundle
         working-directory: app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,16 @@ jobs:
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{env.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{env.PROPERTIES_PATH}}
           echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
+
+      - name: Prepare version name
+        id: version_name
+        run: |
+          echo "${{ github.ref_name }}"
+          echo "${{ github.ref }}"
+          echo "${{ github.ref_name }}" | tr / _
+          echo "version_name=$(echo "${{github.ref_name}}" | tr / _)"
+          echo "version_name=$(echo "${{github.ref_name}}" | tr / _)" >> $GITHUB_OUTPUT
+        
       - name: Build APK
         working-directory: app
         run: flutter build apk --release
@@ -60,30 +70,22 @@ jobs:
         working-directory: app
         run: flutter build appbundle --release
       
-      - name: Prepare version name
-        id: version_name
-        run: |
-          REF_NAME="${{ github.ref_name || github.ref }}"
-          echo "${{ github.ref_name }}"
-          echo "${{ github.ref }}"
-          echo "version_name=REF_NAME" | tr / _ >> $GITHUB_OUTPUT
-        
       - name: Rename APK & App Bundle
         working-directory: app
         run: |
-          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
-          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.version_name }}.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.version_name }}.aab
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
+          path: app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.version_name }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: release-appbundle
-          path: app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
+          path: app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.version_name }}.aab
 
       - name: Release Artifacts
         if: startsWith(github.ref, 'refs/tags/')
@@ -91,5 +93,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.value }}.apk
-            app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.value }}.aab
+            app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.version_name }}.apk
+            app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.version_name }}.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,7 @@ jobs:
 
       - name: Prepare version name
         id: version_name
-        run: |
-          echo "${{ github.ref_name }}"
-          echo "${{ github.ref }}"
-          echo "${{ github.ref_name }}" | tr / _
-          echo "version_name=$(echo "${{github.ref_name}}" | tr / _)"
-          echo "version_name=$(echo "${{github.ref_name}}" | tr / _)" >> $GITHUB_OUTPUT
+        run: echo "version_name=$(echo "${{github.ref_name}}" | tr / _)" >> $GITHUB_OUTPUT
         
       - name: Build APK
         working-directory: app


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow for building and releasing the Flutter app. The changes streamline the handling of version names and improve the readability and maintainability of the workflow.

### Workflow improvements:

* Replaced the use of the `step-security/actions-find-and-replace-string` action with an inline shell script to prepare the version name. The script replaces slashes (`/`) in the branch name with underscores (`_`) and outputs it directly to `$GITHUB_OUTPUT`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R55-R59) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L63-R92)

* Updated references to the version name in subsequent steps (e.g., renaming APK and app bundle files, uploading artifacts, and releasing artifacts) to use the new output variable `steps.version_name.outputs.version_name` instead of the previous `steps.version_name.outputs.value`.