### PR TITLE
♻️ Rename artifacts with a better name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,13 +73,13 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: release-apk
+          name: GitDone_${{ steps.version_name.outputs.version_name }}.apk
           path: app/build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.version_name }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
-          name: release-appbundle
+          name: GitDone_${{ steps.version_name.outputs.version_name }}.aab
           path: app/build/app/outputs/bundle/release/GitDone_${{ steps.version_name.outputs.version_name }}.aab
 
       - name: Release Artifacts


### PR DESCRIPTION
This pull request updates the naming convention for artifacts uploaded in the build workflow to make them more descriptive and version-specific.

Changes to artifact naming in the build workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L76-R82): Updated the names of the APK and App Bundle artifacts to include the version name dynamically, using the format `GitDone_${{ steps.version_name.outputs.version_name }}.apk` and `GitDone_${{ steps.version_name.outputs.version_name }}.aab`.