### PR TITLE
👷 Use dynamic branch for checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: app
+          ref: ${{ github.ref_name }}
 
       - name: Clone Package Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The change ensures that the repository is checked out at the specific branch or tag associated with the workflow run.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R26): Added the `ref` parameter to the `actions/checkout` step, setting it to `${{ github.ref_name }}` to ensure the correct branch or tag is checked out during the workflow.