### PR TITLE
👷 Change the ref in request-build.yml

### DIFF
--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: app
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Clone Package Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure the correct branch is checked out during pull request builds.

* [`.github/workflows/request-build.yml`](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399L28-R28): Updated the `ref` parameter in the `actions/checkout` step to use the pull request's head reference (`github.event.pull_request.head.ref`) instead of the default branch reference (`github.ref_name`).