### PR TITLE
👷 Add jdk setup to request build

### DIFF
--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -38,7 +38,13 @@ jobs:
           channel: ${{ env.FLUTTER_CHANNEL }}
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
-
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          
       - name: Install dependencies
         working-directory: app
         run: flutter pub get


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to include a step for setting up the Java Development Kit (JDK) using the `actions/setup-java` action.

### Workflow improvement:
* [`.github/workflows/request-build.yml`](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399R42-R47): Added a new step to set up the JDK with Temurin distribution and Java version 21. This ensures the required Java environment is available for subsequent steps.