### PR TITLE
👷 Add rename task to request build

### DIFF
--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -67,7 +67,12 @@ jobs:
       - name: Build App Bundle
         working-directory: app
         run: flutter build appbundle --release --flavor production
-
+        
+      - name: Rename APK & App Bundle
+        working-directory: app
+        run: |
+          mv build/app/outputs/flutter-apk/app-production-release.apk build/app/outputs/flutter-apk/GitDone_${{ steps.version_name.outputs.version_name }}.apk
+          mv build/app/outputs/bundle/productionRelease/app-production-release.aab build/app/outputs/bundle/productionRelease/GitDone_${{ steps.version_name.outputs.version_name }}.aab
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request introduces a small but important change to the `.github/workflows/request-build.yml` file. It adds a step to rename the generated APK and App Bundle files to include the app's version name in their filenames for better clarity and organization.

* [`.github/workflows/request-build.yml`](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399R71-R75): Added a new step to rename the APK and App Bundle files to include the version name, using the format `GitDone_<version_name>.apk` and `GitDone_<version_name>.aab`.