### PR TITLE
👷 Add pull request write permissions to request build action

### DIFF
--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
       
+permissions:
+  pull-requests: write
+
 env:
   FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to modify permissions for pull requests. 

Workflow configuration changes:

* [`.github/workflows/request-build.yml`](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399R12-R14): Added `permissions` with `pull-requests: write` to the workflow configuration, enabling write access for pull requests.