### PR TITLE
Remove +1 from Flutter Version Number refactor/

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.0+1
+version: 0.0.0
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
I've checked the codebase, and here are my findings:

The version string is defined only in pubspec.yaml
No deployment configurations depend on the build number suffix
Our app doesn't currently display version information to users that would be affected

Changes made:

Updated version string in pubspec.yaml from 0.0.0+1 to 0.0.0
Verified the app still builds correctly after this change
Confirmed this aligns with our Git tag format for releases