### PR TITLE
👷 Auto remove work in process label from closed issues and PRs

### DIFF
--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove '🚧 Work in Progress' label
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: IamPekka058/removeLabels@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: 🚧 Work in Progress

--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -1,7 +1,10 @@
-name: Update Issue Labels
+name: Actions on issue and pull request close
 
 on:
   issues:
+    types:
+      - closed
+  pull_request:
     types:
       - closed
 

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,16 @@
+name: Update Issue Labels
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  remove-wip-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove '🚧 Work in Progress' label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 🚧 Work in Progress


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate label management when issues or pull requests are closed.

### New GitHub Actions Workflow:

* [`.github/workflows/close-actions.yml`](diffhunk://#diff-df3318838e056a0f4c9cca1f199a7fcbb200587e0529f1d21a0e1fe26c6e2243R1-R19): Introduced a workflow named "Actions on issue and pull request close" that triggers on the closure of issues or pull requests. The workflow includes a job to automatically remove the '🚧 Work in Progress' label using the `actions-ecosystem/action-remove-labels` action.This pull request introduces a new GitHub Actions workflow to automatically remove the "🚧 Work in Progress" label from issues when they are closed.