### PR TITLE
👷 Introduce repository-variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
 env:
-  FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"
   PROPERTIES_PATH: "./app/android/key.properties"
 
@@ -34,7 +33,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
-          flutter-version: ${{ env.FLUTTER_VERSION }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
 env:
-  FLUTTER_CHANNEL: "stable"
   PROPERTIES_PATH: "./app/android/key.properties"
 
 jobs:
@@ -32,7 +31,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          channel: ${{ vars.FLUTTER_CHANNEL }}
           flutter-version: ${{ vars.FLUTTER_VERSION }}
           cache: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: write
-env:
-  PROPERTIES_PATH: "./app/android/key.properties"
 
 jobs:
   build:
@@ -47,9 +45,9 @@ jobs:
 
       - name: Set up keystore
         run: |
-          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{env.PROPERTIES_PATH}}
-          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{env.PROPERTIES_PATH}}
-          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{env.PROPERTIES_PATH}}
+          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
+          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
+          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
           echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
 
       - name: Prepare version name

--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -13,7 +13,6 @@ permissions:
   pull-requests: write
 
 env:
-  FLUTTER_CHANNEL: "stable"
   PROPERTIES_PATH: "./app/android/key.properties"
 
 jobs:
@@ -37,7 +36,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          channel: ${{ vars.FLUTTER_CHANNEL }}
           flutter-version: ${{ vars.FLUTTER_VERSION }}
           cache: true
 

--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -13,7 +13,6 @@ permissions:
   pull-requests: write
 
 env:
-  FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"
   PROPERTIES_PATH: "./app/android/key.properties"
 
@@ -39,7 +38,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
-          flutter-version: ${{ env.FLUTTER_VERSION }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
           cache: true
 
       - name: Set up JDK

--- a/.github/workflows/request-build.yml
+++ b/.github/workflows/request-build.yml
@@ -12,9 +12,6 @@ on:
 permissions:
   pull-requests: write
 
-env:
-  PROPERTIES_PATH: "./app/android/key.properties"
-
 jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, '⚗️ Request Build')
@@ -52,9 +49,9 @@ jobs:
 
       - name: Set up keystore
         run: |
-          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{env.PROPERTIES_PATH}}
-          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{env.PROPERTIES_PATH}}
-          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{env.PROPERTIES_PATH}}
+          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
+          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
+          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
           echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
 
       - name: Prepare version name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{vars.FLUTTER_CHANNEL}}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          channel: ${{vars.FLUTTER_CHANNEL}}
           cache: true
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to replace environment variables (`env`) with reusable variables (`vars`) for better maintainability and consistency. The changes affect both the `build.yml` and `request-build.yml` workflow files.

### Workflow Improvements:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-L14): Replaced `env` with `vars` for `FLUTTER_VERSION`, `FLUTTER_CHANNEL`, and `PROPERTIES_PATH` in the `flutter-action` setup and keystore configuration steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-L14) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L36-R33) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L52-R50)
* [`.github/workflows/request-build.yml`](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399L15-L19): Applied the same replacement of `env` with `vars` for `FLUTTER_VERSION`, `FLUTTER_CHANNEL`, and `PROPERTIES_PATH` in the `flutter-action` setup and keystore configuration steps. [[1]](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399L15-L19) [[2]](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399L41-R37) [[3]](diffhunk://#diff-fe4194bd0593742314ba0f6296f3906a730fc22d986950e3f393a1f7b9871399L57-R54)