### PR TITLE
💚 Fix close-actions.yml permissions

### DIFF
--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -8,6 +8,10 @@ on:
     types:
       - closed
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   remove-wip-label:
     runs-on: ubuntu-latest
@@ -16,4 +20,4 @@ jobs:
         uses: IamPekka058/removeLabels@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 🚧 Work in Progress
+          labels: "🚧 Work in Progress"


### PR DESCRIPTION
This pull request updates the `.github/workflows/close-actions.yml` file to improve permissions and fix a minor issue with label formatting.

Workflow permissions:

* Added explicit `permissions` for `issues: write` and `pull-requests: write` to the workflow configuration.

Label formatting:

* Updated the `labels` value in the `remove-wip-label` job to use consistent string formatting by enclosing the label in double quotes.