### PR TITLE
👷 Update close-actions.yml

### DIFF
--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -1,4 +1,4 @@
-name: Actions on issue and pull request close
+name: Close Actions
 
 on:
   issues:
@@ -13,10 +13,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  remove-wip-label:
+  close-actions:
+    name: Close actions
     runs-on: ubuntu-latest
     steps:
-      - name: Remove '🚧 Work in Progress' label
+      - name: Remove labels
         uses: IamPekka058/removeLabels@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/close-actions.yml` workflow file to rename the workflow and its associated job, as well as generalize the label removal step.

Workflow updates:

* Renamed the workflow from "Actions on issue and pull request close" to "Close Actions" for brevity and clarity.
* Renamed the job from `remove-wip-label` to `close-actions` and updated the job's name to "Close actions" to reflect a broader scope.
* Generalized the label removal step by changing its name from "Remove '🚧 Work in Progress' label" to "Remove labels," indicating it can handle various labels.