### PR TITLE
:construction_worker: Add branch naming enforcement configuration

### DIFF
--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -1,0 +1,13 @@
+- feature/*
+- fix/*
+- hotfix/*
+- docs/*
+- test/*
+- refactor/*
+- style/*
+- ci/*
+- perf/*
+- i18n/*
+- security/*
+- release/*
+- chore/*

--- a/.github/workflows/enforce-branch-names.yml
+++ b/.github/workflows/enforce-branch-names.yml
@@ -1,8 +1,10 @@
 name: Enforce branch names
 
 on:
-  pull_request_target:
-    types: [ opened, synchronize ]
+  pull_request:
+    types:
+    - opened
+    - synchronize
 
 jobs:
   enforce-branch-names:

--- a/.github/workflows/enforce-branch-names.yml
+++ b/.github/workflows/enforce-branch-names.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: IamPekka058/branchMatchRegex@v0
         with:
           path: .github/branches.yml

--- a/.github/workflows/enforce-branch-names.yml
+++ b/.github/workflows/enforce-branch-names.yml
@@ -1,0 +1,15 @@
+name: Enforce branch names
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize ]
+
+jobs:
+  enforce-branch-names:
+    name: Enforce pull request branch names
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: IamPekka058/branchMatchRegex@v0
+        with:
+          path: ./.github/branches.yml

--- a/.github/workflows/enforce-branch-names.yml
+++ b/.github/workflows/enforce-branch-names.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: IamPekka058/branchMatchRegex@v0
         with:
-          path: ./.github/branches.yml
+          path: .github/branches.yml


### PR DESCRIPTION
This pull request introduces a branch naming convention and a GitHub Actions workflow to enforce it. The most important changes include defining allowed branch name patterns and adding a workflow that validates branch names for pull requests.

### Branch naming convention:

* [`.github/branches.yml`](diffhunk://#diff-2b7274ece2bf557d8e7b057da003c3ba13448b23e59615d2f84129288d208fd2R1-R13): Added a configuration file specifying allowed branch name patterns, including prefixes like `feature/*`, `fix/*`, `docs/*`, and others.

### Workflow for enforcement:

* [`.github/workflows/enforce-branch-names.yml`](diffhunk://#diff-cf23e964957a2041cfb9bdc15d7bfd18c9876441acaf724ba8a924649d4e6635R1-R15): Added a GitHub Actions workflow that triggers on pull request events (`opened` and `synchronize`) and validates branch names against the patterns in `.github/branches.yml` using the `IamPekka058/branchMatchRegex` action.