### PR TITLE
:ambulance: Save selected repository on change in repository selector

### DIFF
--- a/lib/ui/settings/widgets/repository_selector/repository_selector_view.dart
+++ b/lib/ui/settings/widgets/repository_selector/repository_selector_view.dart
@@ -47,6 +47,7 @@ class _RepositorySelectorState extends State<RepositorySelector> {
                   items: model.repositories.map(convertRepoToItem).toList(),
                   onChanged: (repo) {
                     model.selectRepository(repo);
+                    model.saveSelectedRepository();
                     ScaffoldMessenger.of(context).hideCurrentSnackBar();
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(


### PR DESCRIPTION
This pull request introduces a small but important change to the `RepositorySelector` widget to ensure the selected repository is saved persistently.

* [`lib/ui/settings/widgets/repository_selector/repository_selector_view.dart`](diffhunk://#diff-1c7adfe14ae445d31194f8e86ed2cd3331829fd6b7919cd2db6b8961de217878R50): Added a call to `model.saveSelectedRepository()` in the `onChanged` callback to save the selected repository when a user makes a selection.