### PR TITLE
💚 Fix sparse-checkout misspelling

### DIFF
--- a/.github/workflows/enforce-conventions.yml
+++ b/.github/workflows/enforce-conventions.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout branches.yml
         uses: actions/checkout@v4
         with:
-          sparseCheckout: .github/branches.yml
+          sparse-checkout: .github/branches.yml
           sparse-checkout-cone-mode: false
 
       - name: Enforce pull request branch names

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout labels.yml
         uses: actions/checkout@v4
         with:
-          sparseCheckout: .github/labels.yml
+          sparse-checkout: .github/labels.yml
           sparse-checkout-cone-mode: false
 
       - name: Sync labels


### PR DESCRIPTION
This pull request updates the syntax of the `actions/checkout` configuration in two GitHub Actions workflows to use the correct `sparse-checkout` parameter name.

Updates to GitHub Actions workflows:

* [`.github/workflows/enforce-conventions.yml`](diffhunk://#diff-59cb6b8dc2f68ae12d0df21055289a416369f0ea3b21972f1577257214b135d9L35-R35): Changed `sparseCheckout` to `sparse-checkout` to align with the correct parameter name in the `actions/checkout` configuration.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L17-R17): Updated `sparseCheckout` to `sparse-checkout` for consistency and correctness in the `actions/checkout` configuration.