### PR TITLE
:construction_worker: Enable wildcard usage

### DIFF
--- a/.github/workflows/enforce-conventions.yml
+++ b/.github/workflows/enforce-conventions.yml
@@ -39,3 +39,4 @@ jobs:
         uses: IamPekka058/branchMatchRegex@v0
         with:
           path: .github/branches.yml
+          useWildcard: true


### PR DESCRIPTION
This pull request includes a small update to the GitHub Actions workflow configuration. The change adds a new `useWildcard` parameter to the `IamPekka058/branchMatchRegex` action in the `.github/workflows/enforce-conventions.yml` file, enabling wildcard support for branch matching