### PR TITLE
👷 Update artifact names

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -116,17 +116,23 @@ jobs:
       - name: Build app bundle
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
+      - name: Rename APK & App Bundle
+        run: |
+          mkdir -p ../build-artifacts
+          mv build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
+          mv build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: GitDone_${{ steps.build_options.outputs.version_name }}.apk
-          path: app/build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk
+          name: GitDone ${{ steps.build_options.outputs.version_name }} APK
+          path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
 
       - name: Upload app bundle
         uses: actions/upload-artifact@v4
         with:
-          name: GitDone_${{ steps.build_options.outputs.version_name }}.aab
-          path: app/build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab
+          name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
+          path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
 
   post-build-requested:
     name: Post requested build


### PR DESCRIPTION
This pull request updates the build workflow in `.github/workflows/test-build-release.yml` to improve artifact naming and organization. The most notable changes involve renaming and relocating APK and AAB files to a dedicated directory before uploading them as artifacts.

### Workflow improvements:

* Added a new step to rename APK and AAB files with the format `GitDone_<version_name>.<extension>` and move them to a `build-artifacts` directory for better organization.
* Updated the `Upload APK` and `Upload app bundle` steps to reference the renamed files in the `build-artifacts` directory and adjusted artifact names for clarity.