### PR TITLE
👷 Update artifact names

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -116,17 +116,23 @@ jobs:
       - name: Build app bundle
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
+      - name: Rename APK & App Bundle
+        run: |
+          mkdir -p ../build-artifacts
+          mv build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
+          mv build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: GitDone_${{ steps.build_options.outputs.version_name }}.apk
-          path: app/build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk
+          name: GitDone ${{ steps.build_options.outputs.version_name }} APK
+          path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
 
       - name: Upload app bundle
         uses: actions/upload-artifact@v4
         with:
-          name: GitDone_${{ steps.build_options.outputs.version_name }}.aab
-          path: app/build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab
+          name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
+          path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
 
   post-build-requested:
     name: Post requested build


### PR DESCRIPTION
This pull request updates the workflow for building and uploading APK and app bundle artifacts in the `.github/workflows/test-build-release.yml` file. The changes introduce a new step to rename and move the generated artifacts to a dedicated directory before uploading them, improving organization and clarity.

### Workflow improvements:
* Added a step to rename APK and app bundle files with a consistent naming convention, including the app version and flavor. The files are moved to a new `build-artifacts` directory for better organization. (`.github/workflows/test-build-release.yml`, [.github/workflows/test-build-release.ymlR119-R135](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR119-R135))
* Updated the upload steps for both APK and app bundle artifacts to reference the renamed files in the `build-artifacts` directory, ensuring consistency in artifact paths and names. (`.github/workflows/test-build-release.yml`, [.github/workflows/test-build-release.ymlR119-R135](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR119-R135))