### PR TITLE
👷 Update artifact names

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -116,17 +116,23 @@ jobs:
       - name: Build app bundle
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
+      - name: Rename APK & App Bundle
+        run: |
+          mkdir -p ../build-artifacts
+          mv build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
+          mv build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: GitDone_${{ steps.build_options.outputs.version_name }}.apk
-          path: app/build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk
+          name: GitDone ${{ steps.build_options.outputs.version_name }} APK
+          path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
 
       - name: Upload app bundle
         uses: actions/upload-artifact@v4
         with:
-          name: GitDone_${{ steps.build_options.outputs.version_name }}.aab
-          path: app/build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab
+          name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
+          path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
 
   post-build-requested:
     name: Post requested build


### PR DESCRIPTION
This pull request updates the `.github/workflows/test-build-release.yml` file to improve the organization of build artifacts and enhance artifact naming conventions. The most important changes include the addition of a step to rename and relocate APK and AAB files, as well as updates to the artifact upload steps to reflect the new file paths and naming conventions.

### Workflow improvements:

* Added a new step to rename APK and AAB files with a more descriptive format (`GitDone_<version_name>.<extension>`) and move them to a dedicated `build-artifacts` directory. This improves file organization and clarity. (`[.github/workflows/test-build-release.ymlR119-R135](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR119-R135)`)
* Updated the paths and names in the "Upload APK" and "Upload app bundle" steps to reflect the new file locations and naming conventions, ensuring consistency and compatibility with the renamed artifacts. (`[.github/workflows/test-build-release.ymlR119-R135](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR119-R135)`)