### PR TITLE
:speech_balloon: Switch from GitHub App to OAuth App

### DIFF
--- a/lib/core/models/github_oauth_model.dart
+++ b/lib/core/models/github_oauth_model.dart
@@ -4,7 +4,7 @@ import 'package:github_flutter/github.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class GitHubAuth {
-  static const String clientId = "Iv23liytEkcJOjMjS9No";
+  static const String clientId = "Ov23li2QBbpgRa3P0GHJ";
   static const String classId =
       "com.GitDone.gitdone.core.models.github_oauth_handler";
   final tokenHandler = TokenHandler();


### PR DESCRIPTION
**This is because of a bug at the rest endpoint 'user/repos' which does not return private repositories for user access tokens.**

Updated the `clientId` in the `GitHubAuth` class from `"Iv23liytEkcJOjMjS9No"` to `"Ov23li2QBbpgRa3P0GHJ"` to use a new OAuth client ID.