### PR TITLE
👷Add size analysis to ci

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,6 +1,9 @@
 - name: ⚗️ Request Build
   description: Requests a build
   color: "7f39fb"
+- name: 🧐 Size Analysis
+  description: Requests a size analysis (only usable with Request Build)
+  color: "006b75"
 - name: 🐛 Bug
   description: Something isn't working
   color: "d73a4a"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,7 +2,7 @@
   description: Requests a build
   color: "7f39fb"
 - name: 🧐 Size Analysis
-  description: Requests a size analysis (only usable with Request Build)
+  description: Request for size analysis of the APK (only alongside a build request)
   color: "006b75"
 - name: 🐛 Bug
   description: Something isn't working

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: /home/runner/.flutter-devtools/apk-code-size-analysis_01.json
+          path: ~/runner/.flutter-devtools/apk-code-size-analysis_01.json
 
   size-analysis:
     needs: test
@@ -215,12 +215,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: /home/runner/.flutter-devtools/apk-code-size-analysis_**.json
+          path: ~/runner/.flutter-devtools/apk-code-size-analysis_01.json
       - name: Upload size analysis apk
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 2
-          path: .flutter-devtools/apk-code-size-analysis_**.json
+          path: .flutter-devtools/apk-code-size-analysis_01.json
 
   post-request:
     name: Post requested build and size analysis

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -93,7 +93,7 @@ jobs:
           echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
-          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
+          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > ${{vars.PROPERTIES_PATH}}
 
       - name: Set build options
         id: build_options
@@ -108,7 +108,7 @@ jobs:
           fi
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA " >> $GITHUB_OUTPUT
+          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA" >> $GITHUB_OUTPUT
 
       - name: Build APK
         run: flutter build apk ${{ steps.build_options.outputs.build_args }}

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -93,7 +93,7 @@ jobs:
           echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
-          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > /app/android/app/key.jks
+          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
 
       - name: Set build options
         id: build_options

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -204,10 +204,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: .flutter-devtools/apk-code-size-analysis_*.json
+          path: .flutter-devtools/apk-code-size-analysis_1.json
 
   post-request:
-    name: Post requested build
+    name: Post requested build and size analysis
     needs: [build, size-analysis]
     if: ${{ contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -138,101 +138,12 @@ jobs:
           name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
           path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
 
+
       - name: Upload size analysis apk
         if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
         uses: actions/upload-artifact@v4
         with:
-          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: ~/runner/.flutter-devtools/apk-code-size-analysis_01.json
-
-  size-analysis:
-    needs: test
-    if: ${{ startsWith(github.ref, 'refs/tags/') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis') }}
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: app
-
-    outputs:
-      version_name: ${{ steps.build_options.outputs.version_name }}
-
-    steps:
-      - name: Checkout app repository
-        uses: actions/checkout@v4
-        with:
-          path: app
-
-      - name: Checkout github_flutter repository
-        uses: actions/checkout@v4
-        with:
-          repository: RubberDuckCrew/github_flutter
-          path: github_flutter
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          flutter-version: ${{ vars.FLUTTER_VERSION }}
-          cache: true
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Install pub dependencies
-        run: flutter pub get
-
-      - name: Set up keystore
-        working-directory: .
-        run: |
-          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
-          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
-          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
-          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
-
-      - name: Set build options
-        id: build_options
-        run: |
-          SHA=${{ github.event.pull_request.head.sha || github.sha }}
-          SHORT_SHA=${SHA:0:7}
-          VERSION_NAME="$(echo "$GITHUB_REF_NAME" | tr / _)_$SHORT_SHA"
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            FLAVOR="production"
-          else
-            FLAVOR="staging"
-          fi
-          echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
-          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --analyze-size --target-platform android-arm64" >> $GITHUB_OUTPUT
-
-      - name: Build APK
-        run: flutter build apk ${{ steps.build_options.outputs.build_args }}
-
-      - name: Upload size analysis apk
-        uses: actions/upload-artifact@v4
-        with:
-          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: ~/runner/.flutter-devtools/apk-code-size-analysis_01.json
-
-      - name: Upload size analysis apk
-        uses: actions/upload-artifact@v4
-        with:
-          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 2
-          path: .flutter-devtools/apk-code-size-analysis_01.json
-
-      - name: Upload size analysis artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: size-analysis
-          path: build/app/outputs/flutter-apk/apk-code-size-analysis_01.json
-
-      - name: Upload size analysis apk
-        uses: actions/upload-artifact@v4
-        with:
-          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 3
+          name: Size Analysis APK ARM64
           path: /home/runner/.flutter-devtools/apk-code-size-analysis_01.json
 
   post-request:

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -204,7 +204,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: .flutter-devtools/*
+          path: /home/runner/.flutter-devtools/apk-code-size-analysis_*.json
+      - name: Upload size analysis apk
+        uses: actions/upload-artifact@v4
+        with:
+          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 2
+          path: .flutter-devtools/apk-code-size-analysis_*.json
 
   post-request:
     name: Post requested build and size analysis

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -236,7 +236,9 @@ jobs:
         uses: IamPekka058/removeLabels@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: ["⚗️ Request Build", "🧐 Size Analysis"]
+          labels: |
+            - ⚗️ Request Build
+            - 🧐 Size Analysis
 
       - name: Comment artifact links
         uses: RubberDuckCrew/artifact2pr@v0

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -138,7 +138,6 @@ jobs:
           name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
           path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
 
-
       - name: Upload size analysis apk
         if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -93,7 +93,7 @@ jobs:
           echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
-          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > ${{vars.PROPERTIES_PATH}}
+          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > ./app/android/app/key.jks
 
       - name: Set build options
         id: build_options

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -93,7 +93,7 @@ jobs:
           echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
-          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > ./app/android/app/key.jks
+          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > /app/android/app/key.jks
 
       - name: Set build options
         id: build_options

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -134,11 +134,71 @@ jobs:
           name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
           path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
 
-      - name: Upload size analysis app bundle
-        uses: actions/upload-artifact@v4
+  size-analysis:
+    needs: test
+    if: ${{ startsWith(github.ref, 'refs/tags/') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis') }}
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: app
+
+    outputs:
+      version_name: ${{ steps.build_options.outputs.version_name }}
+
+    steps:
+      - name: Checkout app repository
+        uses: actions/checkout@v4
         with:
-          name: Size Analysis ${{ steps.build_options.outputs.version_name }} AAB
-          path: build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab.json
+          path: app
+
+      - name: Checkout github_flutter repository
+        uses: actions/checkout@v4
+        with:
+          repository: RubberDuckCrew/github_flutter
+          path: github_flutter
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          flutter-version: ${{ vars.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install pub dependencies
+        run: flutter pub get
+
+      - name: Set up keystore
+        working-directory: .
+        run: |
+          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{vars.PROPERTIES_PATH}}
+          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{vars.PROPERTIES_PATH}}
+          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{vars.PROPERTIES_PATH}}
+          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > app/android/app/key.jks
+
+      - name: Set build options
+        id: build_options
+        run: |
+          SHA=${{ github.event.pull_request.head.sha || github.sha }}
+          SHORT_SHA=${SHA:0:7}
+          VERSION_NAME="$(echo "$GITHUB_REF_NAME" | tr / _)_$SHORT_SHA"
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            FLAVOR="production"
+          else
+            FLAVOR="staging"
+          fi
+          echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --analyze-size" >> $GITHUB_OUTPUT
+
+      - name: Build APK
+        run: flutter build apk ${{ steps.build_options.outputs.build_args }}
 
       - name: Upload size analysis apk
         uses: actions/upload-artifact@v4
@@ -146,11 +206,10 @@ jobs:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
           path: build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk.json
 
-
-  post-build-requested:
+  post-request:
     name: Post requested build
-    needs: build
-    if: contains(github.event.pull_request.labels.*.name, '⚗️ Request Build')
+    needs: build, size-analysis
+    if: contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
     runs-on: ubuntu-latest
 
     permissions:
@@ -161,7 +220,9 @@ jobs:
         uses: IamPekka058/removeLabels@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "⚗️ Request Build"
+          labels: |
+            - "⚗️ Request Build"
+            - "🧐 Size Analysis"
 
       - name: Comment artifact links
         uses: RubberDuckCrew/artifact2pr@v0

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -108,7 +108,7 @@ jobs:
           fi
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --analyze-size" >> $GITHUB_OUTPUT
 
       - name: Build APK
         run: flutter build apk ${{ steps.build_options.outputs.build_args }}
@@ -133,6 +133,19 @@ jobs:
         with:
           name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
           path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
+      - name: Upload size analysis app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: Size Analysis ${{ steps.build_options.outputs.version_name }} AAB
+          path: build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab.json
+
+      - name: Upload size analysis apk
+        uses: actions/upload-artifact@v4
+        with:
+          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
+          path: build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk.json
+
 
   post-build-requested:
     name: Post requested build

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -195,7 +195,7 @@ jobs:
           fi
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --analyze-size" >> $GITHUB_OUTPUT
+          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --analyze-size --target-platform android-arm64" >> $GITHUB_OUTPUT
 
       - name: Build APK
         run: flutter build apk ${{ steps.build_options.outputs.build_args }}
@@ -208,7 +208,7 @@ jobs:
 
   post-request:
     name: Post requested build
-    needs: build, size-analysis
+    needs: [build, size-analysis]
     if: contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -108,7 +108,7 @@ jobs:
           fi
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --analyze-size" >> $GITHUB_OUTPUT
+          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA " >> $GITHUB_OUTPUT
 
       - name: Build APK
         run: flutter build apk ${{ steps.build_options.outputs.build_args }}
@@ -204,12 +204,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk.json
+          path: .flutter-devtools/apk-code-size-analysis_*.json
 
   post-request:
     name: Post requested build
     needs: [build, size-analysis]
-    if: contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
+    if: ${{ contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis') }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -216,11 +216,24 @@ jobs:
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
           path: ~/runner/.flutter-devtools/apk-code-size-analysis_01.json
+
       - name: Upload size analysis apk
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 2
           path: .flutter-devtools/apk-code-size-analysis_01.json
+
+      - name: Upload size analysis artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-analysis
+          path: build/app/outputs/flutter-apk/apk-code-size-analysis_01.json
+
+      - name: Upload size analysis apk
+        uses: actions/upload-artifact@v4
+        with:
+          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 3
+          path: /home/runner/.flutter-devtools/apk-code-size-analysis_01.json
 
   post-request:
     name: Post requested build and size analysis

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -236,9 +236,7 @@ jobs:
         uses: IamPekka058/removeLabels@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            - "⚗️ Request Build"
-            - "🧐 Size Analysis"
+          labels: ["⚗️ Request Build", "🧐 Size Analysis"]
 
       - name: Comment artifact links
         uses: RubberDuckCrew/artifact2pr@v0

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -118,13 +118,14 @@ jobs:
 
       - name: Build APK
         if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
-        run: flutter build apk ${{ steps.build_options.outputs.build_args }}
+        run: flutter build apk ${{ steps.build_options.outputs.build_args }} --analyze-size --target-platform android-arm64
 
       - name: Rename APK & App Bundle
         run: |
           mkdir -p ../build-artifacts
           mv build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
           mv build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
@@ -142,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: /home/runner/.flutter-devtools/apk-code-size-analysis_**.json
+          path: /home/runner/.flutter-devtools/apk-code-size-analysis_01.json
 
   size-analysis:
     needs: test
@@ -214,12 +215,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: /home/runner/.flutter-devtools/apk-code-size-analysis_*.json
+          path: /home/runner/.flutter-devtools/apk-code-size-analysis_**.json
       - name: Upload size analysis apk
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK 2
-          path: .flutter-devtools/apk-code-size-analysis_*.json
+          path: .flutter-devtools/apk-code-size-analysis_**.json
 
   post-request:
     name: Post requested build and size analysis

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -204,7 +204,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
-          path: .flutter-devtools/apk-code-size-analysis_1.json
+          path: .flutter-devtools/*
 
   post-request:
     name: Post requested build and size analysis

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -116,12 +116,15 @@ jobs:
       - name: Build app bundle
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
+      - name: Build APK
+        if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
+        run: flutter build apk ${{ steps.build_options.outputs.build_args }}
+
       - name: Rename APK & App Bundle
         run: |
           mkdir -p ../build-artifacts
           mv build/app/outputs/flutter-apk/app-${{ steps.build_options.outputs.flavor }}-release.apk ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.apk
           mv build/app/outputs/bundle/${{ steps.build_options.outputs.flavor }}Release/app-${{ steps.build_options.outputs.flavor }}-release.aab ../build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
-
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
@@ -133,6 +136,13 @@ jobs:
         with:
           name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
           path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
+      - name: Upload size analysis apk
+        if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
+        uses: actions/upload-artifact@v4
+        with:
+          name: Size Analysis ${{ steps.build_options.outputs.version_name }} APK
+          path: /home/runner/.flutter-devtools/apk-code-size-analysis_**.json
 
   size-analysis:
     needs: test
@@ -213,8 +223,8 @@ jobs:
 
   post-request:
     name: Post requested build and size analysis
-    needs: [build, size-analysis]
-    if: ${{ contains(github.event.pull_request.labels.*.name, '⚗️ Request Build') || contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis') }}
+    needs: build
+    if: contains(github.event.pull_request.labels.*.name, '⚗️ Request Build')
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
This pull request introduces a new feature for size analysis during the build process and updates the workflow configuration to support it. The most important changes involve adding a new label for size analysis, modifying the build workflow to conditionally include size analysis steps, and updating the post-build process to handle the new functionality.

### New Label for Size Analysis:
* [`.github/labels.yml`](diffhunk://#diff-080b7ef0dc11b28f262ea02985043c6229e353ecfdd5920b4d3b19f369f85dc6R4-R6): Added a new label `🧐 Size Analysis` with a description indicating its use for requesting size analysis alongside a build.

### Workflow Updates for Size Analysis:
* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR119-R122): Added a conditional step to build an APK with size analysis enabled if the `🧐 Size Analysis` label is present.
* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL137-R149): Included a step to upload the size analysis results as an artifact when the size analysis label is applied.

### Post-Build Process Updates:
* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL151-R164): Renamed and updated the post-build job to handle both build and size analysis requests, ensuring appropriate labels are removed after processing.