### PR TITLE
:sparkles: Add onUpdate callback to FilterChipDropdown

### DIFF
--- a/lib/ui/home/widgets/dropdown_filter_chip.dart
+++ b/lib/ui/home/widgets/dropdown_filter_chip.dart
@@ -17,7 +17,7 @@ class FilterChipDropdown extends StatefulWidget {
   final String initialLabel;
   final double labelPadding;
   final bool allowMultipleSelection;
-  final void Function(FilterChipItem) onItemSelected;
+  final void Function(FilterChipItem) onUpdate;
 
   const FilterChipDropdown({
     super.key,
@@ -25,7 +25,7 @@ class FilterChipDropdown extends StatefulWidget {
     this.leading,
     required this.initialLabel,
     required this.allowMultipleSelection,
-    required this.onItemSelected,
+    required this.onUpdate,
     this.labelPadding = 16,
   });
 
@@ -121,7 +121,7 @@ class _FilterChipDropdownState extends State<FilterChipDropdown> {
                                             : Colors.transparent,
                                     child: InkWell(
                                       onTap: () {
-                                        widget.onItemSelected(item);
+                                        widget.onUpdate(item);
 
                                         if (viewModel.isItemSelected(item) &&
                                             widget.allowMultipleSelection) {


### PR DESCRIPTION
This pull request introduces a new callback to the `FilterChipDropdown` widget to allow external handling of item selection events. It also updates the internal logic to invoke this callback whenever an item is selected or unselected.

### Enhancements to `FilterChipDropdown`:

* **Added `onItemSelected` callback**: A new `void Function(FilterChipItem)` callback parameter, `onItemSelected`, was added to the `FilterChipDropdown` widget to notify external components when an item is selected. (`lib/ui/home/widgets/dropdown_filter_chip.dart`, [lib/ui/home/widgets/dropdown_filter_chip.dartR20-R28](diffhunk://#diff-b0ac737272a4705a749442d8d9deafd9d086fb15042beec8df0e1e696e58d1ceR20-R28))

* **Updated item selection logic**: Modified the `onTap` handler in `_FilterChipDropdownState` to invoke the `onItemSelected` callback before proceeding with internal selection or unselection logic. (`lib/ui/home/widgets/dropdown_filter_chip.dart`, [lib/ui/home/widgets/dropdown_filter_chip.dartL121-R132](diffhunk://#diff-b0ac737272a4705a749442d8d9deafd9d086fb15042beec8df0e1e696e58d1ceL121-R132))