### PR TITLE
:construction_worker: Add obfuscation and symbol upload to build ci

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: GitDone ${{ steps.build_options.outputs.version_name }} Symbols
-          path: build/app/symbols
+          path: app/build/app/symbols
 
       - name: Upload size analysis apk
         if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -108,7 +108,7 @@ jobs:
           fi
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "build_args=--release --flavor $FLAVOR --dart-define=GIT_COMMIT=$SHORT_SHA --obfuscate --split-debug-info=build/app/symbols" >> $GITHUB_OUTPUT
 
       - name: Build APK
         run: flutter build apk ${{ steps.build_options.outputs.build_args }}
@@ -116,7 +116,7 @@ jobs:
       - name: Build app bundle
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
-      - name: Build APK
+      - name: Build APK for size analysis
         if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')
         run: flutter build apk ${{ steps.build_options.outputs.build_args }} --analyze-size --target-platform android-arm64
 
@@ -137,6 +137,12 @@ jobs:
         with:
           name: GitDone ${{ steps.build_options.outputs.version_name }} AAB
           path: build-artifacts/GitDone_${{ steps.build_options.outputs.version_name }}.aab
+
+      - name: Upload symbols file
+        uses: actions/upload-artifact@v4
+        with:
+          name: GitDone ${{ steps.build_options.outputs.version_name }} Symbols
+          path: build/app/symbols
 
       - name: Upload size analysis apk
         if: contains(github.event.pull_request.labels.*.name, '🧐 Size Analysis')


### PR DESCRIPTION
This pull request updates the build and release workflow in `.github/workflows/test-build-release.yml` to enhance build configurations and artifact management. The most important changes include adding obfuscation and split-debug-info options to the build process, renaming a build step for clarity, and introducing a new step to upload symbols files.

### Enhancements to build configurations:
* Updated the `build_args` to include `--obfuscate` and `--split-debug-info=build/app/symbols` for better code obfuscation and debug symbol management.

### Improvements to artifact management:
* Added a new step to upload the symbols file (`build/app/symbols`) as an artifact for debugging purposes.

### Workflow clarity:
* Renamed the "Build APK" step to "Build APK for size analysis" to better reflect its purpose when the `🧐 Size Analysis` label is applied.