### PR TITLE
👷 Add scheduled scanning

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,20 +1,13 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# A sample workflow which sets up periodic OSV-Scanner scanning for vulnerabilities,
-# in addition to a PR check which fails if new vulnerabilities are introduced.
-#
-# For more examples and options, including how to ignore specific vulnerabilities,
-# see https://google.github.io/osv-scanner/github-action/
-
 name: OSV-Scanner
 
 on:
   pull_request:
     branches: [ "main" ]
   merge_group:
+    branches: [ "main" ]
+  schedule:
+    - cron: '32 6 * * 4'
+  push:
     branches: [ "main" ]
 
 permissions:
@@ -26,11 +19,10 @@ permissions:
   contents: read
 
 jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.0.2"
+
   scan-pr:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.0.2"
-    with:
-      # Example of specifying custom arguments
-      scan-args: |-
-        -r
-        --skip-git
-        ./


### PR DESCRIPTION
This pull request updates the `.github/workflows/osv-scanner.yml` file to enhance the OSV-Scanner workflow by adding scheduled scans and refining the conditions for job execution. The changes aim to improve automation and streamline vulnerability scanning processes.

### Enhancements to OSV-Scanner Workflow:

* Added a `schedule` trigger to run the OSV-Scanner every Thursday at 6:32 AM (`cron: '32 6 * * 4'`) and included a `push` trigger for the `main` branch. This ensures periodic and automated scans in addition to scans triggered by pull requests and merge groups.

* Introduced a new `scan-scheduled` job that runs only for `push` or `schedule` events, utilizing the reusable workflow `osv-scanner-reusable.yml` from version `v2.0.2`. This separates scheduled scans from pull request scans for better clarity and management.

* Updated the `scan-pr` job to explicitly run for `pull_request` or `merge_group` events and removed custom arguments (`scan-args`) that were previously used. This simplifies the configuration and aligns it with reusable workflows.