### PR TITLE
🔧 Rename staging flavor to testing

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -109,7 +109,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             FLAVOR="production"
           else
-            FLAVOR="staging"
+            FLAVOR="testing"
           fi
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,9 +52,9 @@ android {
             applicationIdSuffix = ".dev"
             resValue "string", "app_name", "GitDone Dev"
         }
-        create("staging") {
+        create("testing") {
             dimension = "default"
-            applicationIdSuffix = ".stg"
+            applicationIdSuffix = ".test"
             resValue "string", "app_name", "GitDone Test"
         }
         create("production") {


### PR DESCRIPTION
This pull request updates the environment naming conventions from "staging" to "testing" to better align with the intended usage. The changes affect both the GitHub Actions workflow and the Android project configuration.

### Environment Naming Updates:

* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL112-R112): Updated the `FLAVOR` variable assignment in the GitHub Actions workflow to use "testing" instead of "staging" when the branch is not a tag.
* [`android/app/build.gradle`](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L55-R57): Renamed the "staging" build flavor to "testing," updated its `applicationIdSuffix` to `.test`, and changed the app name to "GitDone Test."