### PR TITLE
👷 Delete branch caches on PR close

### DIFF
--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
 
     steps:
       - name: Remove labels
@@ -21,3 +22,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: "🚧 Work in Progress"
+
+      - name: Delete branch caches
+        if: startsWith(github.ref, "refs/pull/")
+        uses: Friedinger/DeleteBranchCaches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}

--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -24,8 +24,8 @@ jobs:
           labels: "🚧 Work in Progress"
 
       - name: Delete branch caches
-        if: startsWith(github.ref, "refs/pull/")
+        if: github.event_name == 'pull_request'
         uses: Friedinger/DeleteBranchCaches@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.ref }}
+          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"


### PR DESCRIPTION
This pull request updates the `.github/workflows/close-actions.yml` file to enhance functionality in the workflow. The key changes include adding permissions for actions and introducing a new step to delete branch caches.

Workflow enhancements:

* Added `actions: write` to the `permissions` block to grant write access to GitHub Actions.
* Introduced a new step using the `Friedinger/DeleteBranchCaches@v1` action to delete branch caches for pull request references. This step is conditionally executed when the branch reference starts with `refs/pull/`.