### PR TITLE
:construction_worker: Add GitHub Actions workflow to update linked issues to status "In Review"

### DIFF
--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -1,0 +1,88 @@
+name: Move Linked Issue to Review in GitHub Project
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  update_project_status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+
+    steps:
+      - name: Extract linked issue number from PR body
+        id: extract
+        run: |
+          ISSUE_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oE '#[0-9]+' | tr -d '#' | head -n1)
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No linked issue found in PR body."
+            exit 0
+          fi
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Get Issue ID and Project Item ID
+        id: ids
+        uses: octokit/graphql-action@v2.x
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          query: |
+            query($owner: String!, $repo: String!, $issueNumber: Int!, $projectId: ID!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issueNumber) {
+                  id
+                }
+              }
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100) {
+                    nodes {
+                      id
+                        content {
+                          ... on Issue {
+                            id
+                            number
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables: |
+            {
+              "owner": "${{ github.repository_owner }}",
+              "repo": "${{ github.event.repository.name }}",
+              "issueNumber": ${{ steps.extract.outputs.issue_number }},
+              "projectId": "PVT_kwDODFbjbM4A-8yd"
+            }
+
+      - name: Extract matching item ID
+        id: match
+        run: |
+          ISSUE_ID=$(echo '${{ steps.ids.outputs.data }}' | jq -r '.repository.issue.id')
+          ITEM_ID=$(echo '${{ steps.ids.outputs.data }}' | jq -r '.node.items.nodes[] | select(.content.id == "'"$ISSUE_ID"'") | .id')
+          echo "issue_id=$ISSUE_ID" >> $GITHUB_OUTPUT
+          echo "item_id=$ITEM_ID" >> $GITHUB_OUTPUT
+
+      - name: Update status to "In Review"
+        uses: octokit/graphql-action@v2.x
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          query: |
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "PVT_kwDODFbjbM4A-8yd",
+                itemId: "${{ steps.match.outputs.item_id }}",
+                fieldId: "PVTSSF_lADODFbjbM4A-8ydzgyMt1Q",
+                value: {
+                  singleSelectOptionId: "5ef0dc97"
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }

--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -8,7 +8,7 @@ jobs:
   update_project_status:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
       issues: write
 

--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
 
     steps:
       - name: Extract linked issue number from PR body
@@ -25,9 +25,10 @@ jobs:
 
       - name: Get Issue ID and Project Item ID
         id: ids
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: octokit/graphql-action@v2.x
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           query: |
             query($owner: String!, $repo: String!, $issueNumber: Int!, $projectId: ID!) {
               repository(owner: $owner, name: $repo) {
@@ -69,8 +70,9 @@ jobs:
 
       - name: Update status to "In Review"
         uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           query: |
             mutation {
               updateProjectV2ItemFieldValue(input: {


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of updating the status of a linked issue in a GitHub Project when a pull request is opened or updated. The workflow extracts the linked issue from the PR body, finds the corresponding project item, and sets its status to "In Review".

**New GitHub Actions workflow for automated issue status updates:**

* Adds `.github/workflows/update-issue-status.yml` to automatically move a linked issue to the "In Review" status in the GitHub Project when a pull request is opened or synchronized.
* The workflow extracts the issue number from the PR body, retrieves the corresponding project item, and updates its status using the GitHub GraphQL API.

Closes: #172 