### PR TITLE
✨Edit labels of task

### DIFF
--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -19,13 +19,13 @@ class TaskHandler extends ChangeNotifier {
 
   List<Task> _tasks = [];
 
-  List<IssueLabel> _labels = [];
+  List<IssueLabel> _repoLabels = [];
 
   /// The list of all tasks available in the repository.
   List<Task> get tasks => List.unmodifiable(_tasks);
 
   /// The list of all labels available in the repository.
-  List<IssueLabel> get allLabels => List.unmodifiable(_labels);
+  List<IssueLabel> get repoLabels => List.unmodifiable(_repoLabels);
 
   /// The list of all tasks available in the repository.
   /// After the notification the current list of task is stored in [tasks].
@@ -55,20 +55,20 @@ class TaskHandler extends ChangeNotifier {
   }
 
   /// The list of all labels available in the repository.
-  /// After the notification the current list of labels is stored in [allLabels].
+  /// After the notification the current list of labels is stored in [repoLabels].
   Future<void> loadLabels() async {
     try {
-      _labels.clear();
+      _repoLabels.clear();
       final RepositoryDetails? repo = await _getSelectedRepository();
       if (repo == null) {
         Logger.logWarning("No repository selected", _classId);
         return;
       }
-      _labels = await (await GithubModel.github).issues
+      _repoLabels = await (await GithubModel.github).issues
           .listLabels(repo.toSlug())
           .toList();
       Logger.logInfo(
-        "Loaded ${_labels.length} labels from repository ${repo.toSlug()}",
+        "Loaded ${_repoLabels.length} labels from repository ${repo.toSlug()}",
         _classId,
       );
       notifyListeners();

--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -67,6 +67,10 @@ class TaskHandler extends ChangeNotifier {
       _labels = await (await GithubModel.github).issues
           .listLabels(repo.toSlug())
           .toList();
+      Logger.logInfo(
+        "Loaded ${_labels.length} labels from repository ${repo.toSlug()}",
+        _classId,
+      );
       notifyListeners();
     } on Exception catch (e) {
       Logger.logError("Failed to load labels", _classId, e);

--- a/lib/ui/task_details/task_details_view.dart
+++ b/lib/ui/task_details/task_details_view.dart
@@ -98,8 +98,7 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
 
   Future<void> _editTask() async {
     Logger.log("Edit task: ${widget.task.title}", _classId, LogLevel.detailed);
-    final Task? updated =
-        await Navigation.navigate(TaskEditView(widget.task)) as Task?;
+    final Task? updated = await Navigation.navigate(TaskEditView(widget.task));
     if (updated == null) {
       Logger.log("Task edit cancelled or failed", _classId, LogLevel.detailed);
       return;

--- a/lib/ui/task_edit/task_edit_view.dart
+++ b/lib/ui/task_edit/task_edit_view.dart
@@ -93,7 +93,7 @@ class _TaskEditViewState extends State<TaskEditView> {
 
   Widget _editLabels(final TaskEditViewModel viewModel) =>
       MultiDropdown<IssueLabel>(
-        items: viewModel.allLabels,
+        items: viewModel.taskLabels,
         controller: _labelController,
         searchEnabled: false,
         chipDecoration: ChipDecoration(

--- a/lib/ui/task_edit/task_edit_view.dart
+++ b/lib/ui/task_edit/task_edit_view.dart
@@ -51,15 +51,14 @@ class _TaskEditViewState extends State<TaskEditView> {
       builder: (final context, final viewModel, _) => Scaffold(
         appBar: const NormalAppBar(),
         body: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 16,
             children: [
               _editTitle(viewModel),
               _editLabels(viewModel),
-              const Padding(padding: EdgeInsets.all(8)),
               _editDescription(viewModel),
-              const Padding(padding: EdgeInsets.all(10)),
             ],
           ),
         ),
@@ -83,16 +82,13 @@ class _TaskEditViewState extends State<TaskEditView> {
     ),
   );
 
-  Widget _editTitle(final TaskEditViewModel viewModel) => Padding(
-    padding: const EdgeInsets.symmetric(vertical: 16),
-    child: TextField(
-      controller: _titleController,
-      decoration: const InputDecoration(
-        labelText: "Title",
-        border: OutlineInputBorder(),
-      ),
-      onSubmitted: viewModel.updateTitle,
+  Widget _editTitle(final TaskEditViewModel viewModel) => TextField(
+    controller: _titleController,
+    decoration: const InputDecoration(
+      labelText: "Title",
+      border: OutlineInputBorder(),
     ),
+    onSubmitted: viewModel.updateTitle,
   );
 
   Widget _editLabels(final TaskEditViewModel viewModel) =>

--- a/lib/ui/task_edit/task_edit_view_model.dart
+++ b/lib/ui/task_edit/task_edit_view_model.dart
@@ -55,6 +55,9 @@ class TaskEditViewModel extends ChangeNotifier {
       _classId,
       LogLevel.detailed,
     );
+    _titleController.text = _task.title;
+    _labelController.setItems(allLabels);
+    _descriptionController.text = _task.description;
     notifyListeners();
   }
 

--- a/lib/ui/task_edit/task_edit_view_model.dart
+++ b/lib/ui/task_edit/task_edit_view_model.dart
@@ -2,6 +2,7 @@ import "package:gitdone/core/models/task.dart";
 import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/core/utils/logger.dart";
 import "package:gitdone/core/utils/navigation.dart";
+import "package:github_flutter/github.dart";
 
 /// A view model for editing a task item.
 class TaskEditViewModel {
@@ -39,7 +40,12 @@ class TaskEditViewModel {
     Logger.log("Updated title: $title", _classId, LogLevel.detailed);
   }
 
-  /// Update the description of the to do item.
+  /// Update the labels of the task item.
+  void updateLabels(final List<IssueLabel> labels) {
+    newTask.labels = labels;
+    Logger.log("Updated labels: $labels", _classId, LogLevel.detailed);
+  }
+
   /// Update the description of the task item.
   void updateDescription(final String description) {
     newTask.description = description;

--- a/lib/ui/task_edit/task_edit_view_model.dart
+++ b/lib/ui/task_edit/task_edit_view_model.dart
@@ -1,21 +1,83 @@
+import "package:flutter/cupertino.dart";
 import "package:gitdone/core/models/task.dart";
 import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/core/utils/logger.dart";
 import "package:gitdone/core/utils/navigation.dart";
 import "package:github_flutter/github.dart";
+import "package:multi_dropdown/multi_dropdown.dart";
 
 /// A view model for editing a task item.
-class TaskEditViewModel {
+class TaskEditViewModel extends ChangeNotifier {
   /// Creates a [TaskEditViewModel] with the given task item.
-  TaskEditViewModel(this._originalTask) : newTask = _originalTask.copy();
+  TaskEditViewModel({
+    required final Task task,
+    required final titleController,
+    required final descriptionController,
+    required final labelController,
+  }) : _task = task.copy(),
+       _titleController = titleController,
+       _descriptionController = descriptionController,
+       _labelController = labelController {
+    _taskHandler.addListener(_listener);
+    _titleController.text = _task.title;
+    _descriptionController.text = _task.description;
+    notifyListeners();
+  }
 
   static const _classId =
       "com.GitDone.gitdone.ui.task_edit.task_edit_view_model";
 
-  final Task _originalTask;
+  final Task _task;
+  final TaskHandler _taskHandler = TaskHandler();
+  final TextEditingController _titleController;
+  final TextEditingController _descriptionController;
+  final MultiSelectController<IssueLabel> _labelController;
 
-  /// The updated task item that is being edited.
-  final Task newTask;
+  /// The list of all labels available in the repository.
+  List<DropdownItem<IssueLabel>> get allLabels {
+    final Set<String> selectedLabels = _task.labels
+        .map((final label) => label.name)
+        .toSet();
+    return _taskHandler.allLabels
+        .map(
+          (final label) => DropdownItem(
+            label: label.name,
+            value: label,
+            selected: selectedLabels.contains(label.name),
+          ),
+        )
+        .toList();
+  }
+
+  void _listener() {
+    Logger.log(
+      "TaskHandler updated, refreshing task edit view",
+      _classId,
+      LogLevel.detailed,
+    );
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    Logger.logInfo("Disposing TaskEditViewModel", _classId);
+    _taskHandler.removeListener(_listener);
+    super.dispose();
+  }
+
+  /// Saves the changes made to the task item.
+  void save() {
+    updateTitle(_titleController.text);
+    updateDescription(_descriptionController.text);
+    updateLabels(
+      _labelController.selectedItems.map((final item) => item.value).toList(),
+    );
+    Logger.log("Saving task: $_task", _classId, LogLevel.detailed);
+    TaskHandler().saveTask(_task);
+    _task.updatedAt = DateTime.now();
+    TaskHandler().updateLocalTask(_task);
+    Navigation.navigateBack(_task);
+  }
 
   /// Cancels the editing of the task item.
   void cancel() {
@@ -23,32 +85,21 @@ class TaskEditViewModel {
     Navigation.navigateBack();
   }
 
-  /// Saves the changes made to the task item.
-  void save() {
-    Logger.log("Saving task: $newTask", _classId, LogLevel.detailed);
-    TaskHandler().saveTask(newTask);
-    newTask.updatedAt = DateTime.now();
-    TaskHandler().updateLocalTask(newTask);
-
-    _originalTask.replace(newTask);
-    Navigation.navigateBack(newTask);
-  }
-
   /// Update the title of the task item.
   void updateTitle(final String title) {
-    newTask.title = title;
+    _task.title = title;
     Logger.log("Updated title: $title", _classId, LogLevel.detailed);
   }
 
   /// Update the labels of the task item.
   void updateLabels(final List<IssueLabel> labels) {
-    newTask.labels = labels;
+    _task.labels = labels;
     Logger.log("Updated labels: $labels", _classId, LogLevel.detailed);
   }
 
   /// Update the description of the task item.
   void updateDescription(final String description) {
-    newTask.description = description;
+    _task.description = description;
     Logger.log(
       "Updated description: $description",
       _classId,

--- a/lib/ui/task_edit/task_edit_view_model.dart
+++ b/lib/ui/task_edit/task_edit_view_model.dart
@@ -3,9 +3,9 @@ import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/core/utils/logger.dart";
 import "package:gitdone/core/utils/navigation.dart";
 
-/// A view model for editing a to do item.
+/// A view model for editing a task item.
 class TaskEditViewModel {
-  /// Creates a [TaskEditViewModel] with the given to do item.
+  /// Creates a [TaskEditViewModel] with the given task item.
   TaskEditViewModel(this._originalTask) : newTask = _originalTask.copy();
 
   static const _classId =
@@ -13,16 +13,16 @@ class TaskEditViewModel {
 
   final Task _originalTask;
 
-  /// The updated to do item that is being edited.
+  /// The updated task item that is being edited.
   final Task newTask;
 
-  /// Cancels the editing of the to do item.
+  /// Cancels the editing of the task item.
   void cancel() {
     Logger.log("Cancel editing task", _classId, LogLevel.detailed);
     Navigation.navigateBack();
   }
 
-  /// Saves the changes made to the to do item.
+  /// Saves the changes made to the task item.
   void save() {
     Logger.log("Saving task: $newTask", _classId, LogLevel.detailed);
     TaskHandler().saveTask(newTask);
@@ -33,13 +33,14 @@ class TaskEditViewModel {
     Navigation.navigateBack(newTask);
   }
 
-  /// Update the title of the to do item.
+  /// Update the title of the task item.
   void updateTitle(final String title) {
     newTask.title = title;
     Logger.log("Updated title: $title", _classId, LogLevel.detailed);
   }
 
   /// Update the description of the to do item.
+  /// Update the description of the task item.
   void updateDescription(final String description) {
     newTask.description = description;
     Logger.log(

--- a/lib/ui/task_edit/task_edit_view_model.dart
+++ b/lib/ui/task_edit/task_edit_view_model.dart
@@ -38,7 +38,7 @@ class TaskEditViewModel extends ChangeNotifier {
 
   /// Label items for the task being edited.
   List<DropdownItem<IssueLabel>> get taskLabels {
-    final List<IssueLabel> currentRepoLabels = _taskHandler.allLabels;
+    final List<IssueLabel> currentRepoLabels = _taskHandler.repoLabels;
     if (_taskLabelItems.isEmpty || !identical(_repoLabels, currentRepoLabels)) {
       _repoLabels = currentRepoLabels;
       _taskLabelItems = _repoLabels

--- a/lib/ui/task_list/task_list_view_model.dart
+++ b/lib/ui/task_list/task_list_view_model.dart
@@ -36,7 +36,7 @@ class TaskListViewModel extends ChangeNotifier {
   List<Task> get tasks => _filteredTasks;
 
   /// The list of labels currently being filtered.
-  List<IssueLabel> get allLabels => _taskHandler.allLabels;
+  List<IssueLabel> get allLabels => _taskHandler.repoLabels;
 
   /// The list of labels used for filtering tasks.
   bool get isEmpty => _isEmpty;
@@ -47,7 +47,7 @@ class TaskListViewModel extends ChangeNotifier {
 
     if (selected) {
       _filterLabels.addAll(
-        _taskHandler.allLabels.where((final l) => l.name == label),
+        _taskHandler.repoLabels.where((final l) => l.name == label),
       );
     } else {
       _filterLabels.removeWhere((final l) => l.name == label);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -303,6 +303,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  multi_dropdown:
+    dependency: "direct main"
+    description:
+      name: multi_dropdown
+      sha256: da25f6defdc62aaf8ce0842d31ff7875fad29aeb13f5b2de9e157a06d53f4b74
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   package_info_plus: ^8.3.0
   markdown_widget: ^2.3.2+8
   intl: ^0.20.2
+  multi_dropdown: ^3.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request enhances the task editing experience in the app by introducing multi-select label editing for tasks. The main changes involve integrating the `multi_dropdown` package, updating the UI to allow label selection, and adding logic to handle label updates in the view model.

**UI/UX Improvements:**

* Replaced the old label display with a new multi-select dropdown (`MultiDropdown<IssueLabel>`) in `TaskEditView`, allowing users to select multiple labels for a task. This includes custom styling and proper initialization of selected labels. [[1]](diffhunk://#diff-f50df844d826ae36f299622e936a5116a3d66247060b882844504621472d51beR31-R36) [[2]](diffhunk://#diff-f50df844d826ae36f299622e936a5116a3d66247060b882844504621472d51beR46-R64) [[3]](diffhunk://#diff-f50df844d826ae36f299622e936a5116a3d66247060b882844504621472d51beL56-R79) [[4]](diffhunk://#diff-f50df844d826ae36f299622e936a5116a3d66247060b882844504621472d51beL82-R153)
* Added the `multi_dropdown` package to dependencies in `pubspec.yaml` to support the new label selection UI.

**Logic and Data Handling:**

* Updated `TaskEditViewModel` to include an `updateLabels` method, enabling the view model to handle changes to the task's labels and log updates.

**Code Quality and Consistency:**

* Improved documentation in `TaskEditViewModel` to consistently refer to "task item" instead of "to do item" and clarified comments.

**Imports and Dependencies:**

* Added necessary imports for `multi_dropdown`, label models, and theme colors to support the new label editing functionality in `TaskEditView`.