### PR TITLE
:adhesive_bandage: Prevent duplicate tasks in local list when saving

### DIFF
--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -82,7 +82,6 @@ class TaskHandler extends ChangeNotifier {
 
       // Add the created task to the local list of tasks if it does not already exist
       // This prevents duplicates in the local task list.
-      // Reference: https://github.com/RubberDuckCrew/gitdone/issues/179
       if (!_tasks.any((final t) => t.issueNumber == createdTask.issueNumber)) {
         _tasks.add(createdTask);
       }

--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -79,7 +79,14 @@ class TaskHandler extends ChangeNotifier {
   Future<Task> saveTask(final Task task) async {
     try {
       final Task createdTask = await task.saveRemote();
-      _tasks.add(createdTask);
+
+      // Add the created task to the local list of tasks if it does not already exist
+      // This prevents duplicates in the local task list.
+      // Reference: https://github.com/RubberDuckCrew/gitdone/issues/179
+      if (!_tasks.any((final t) => t.issueNumber == createdTask.issueNumber)) {
+        _tasks.add(createdTask);
+      }
+
       notifyListeners();
       return createdTask;
     } on Exception catch (e) {


### PR DESCRIPTION
This pull request improves the task saving logic to prevent duplicate tasks from being added to the local task list. Now, when a new task is saved remotely, it will only be added to the local list if it does not already exist.

Task list management:

* Updated the `saveTask` method in `TaskHandler` to check for existing tasks before adding a new one to the local `_tasks` list, preventing duplicates.