### PR TITLE
:bug: Update navigation to use clean transition to MainScreen after login

### DIFF
--- a/lib/ui/login/oauth/login_oauth_view_model.dart
+++ b/lib/ui/login/oauth/login_oauth_view_model.dart
@@ -35,7 +35,7 @@ class LoginGithubViewModel extends ChangeNotifier {
       return;
     }
 
-    Navigation.navigate(const MainScreen());
+    Navigation.navigateClean(const MainScreen());
   }
 
   /// Retries the login process after an error has occurred.


### PR DESCRIPTION
This pull request makes a small update to the navigation logic after a successful login. The change ensures that when navigating to the `MainScreen`, the navigation stack is cleared, preventing users from returning to the login screen.

* Use `Navigation.navigateClean` instead of `Navigation.navigate` to transition to `MainScreen`, ensuring a clean navigation stack after login (`lib/ui/login/oauth/login_oauth_view_model.dart`).