### PR TITLE
✨ Mark task as done

### DIFF
--- a/lib/core/models/task.dart
+++ b/lib/core/models/task.dart
@@ -1,4 +1,5 @@
 import "package:gitdone/core/models/github_model.dart";
+import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/core/utils/logger.dart";
 import "package:github_flutter/github.dart";
 
@@ -12,10 +13,11 @@ class Task {
     required final slug,
     required this.createdAt,
     required this.updatedAt,
-    this.state = "open",
+    required final IssueState issueState,
     this.closedAt,
     final issueNumber,
-  }) : _slug = slug,
+  }) : state = issueState.value,
+       _slug = slug,
        _issueNumber = issueNumber;
 
   /// Creates a to do instance from a GitHub [Issue].
@@ -39,7 +41,7 @@ class Task {
       closedAt = null,
       _slug = slug,
       _issueNumber = null,
-      state = "open";
+      state = IssueState.open.value;
 
   static const _classId = "com.GitDone.gitdone.core.models.task";
 
@@ -124,7 +126,7 @@ class Task {
     closedAt: closedAt,
     slug: _slug,
     issueNumber: _issueNumber,
-    state: state,
+    issueState: IssueState.fromValue(state),
   );
 
   /// Replaces the current instance with the values from another to do instance.

--- a/lib/core/models/task.dart
+++ b/lib/core/models/task.dart
@@ -14,7 +14,6 @@ class Task {
     required this.updatedAt,
     this.state = "open",
     this.closedAt,
-    this.stateReason,
     final issueNumber,
   }) : _slug = slug,
        _issueNumber = issueNumber;
@@ -28,8 +27,7 @@ class Task {
       closedAt = issue.closedAt,
       labels = issue.labels,
       _issueNumber = issue.number,
-      state = issue.state,
-      stateReason = issue.stateReason;
+      state = issue.state;
 
   /// Creates an empty task with the given [slug].
   Task.createEmpty(final RepositorySlug slug)
@@ -74,9 +72,6 @@ class Task {
   /// The state of the task, e.g., "OPEN" or "CLOSED".
   String state;
 
-  /// The reason for the current state of the task, if applicable.
-  String? stateReason;
-
   /// Saves the current task to the remote repository.
   Future<Task> saveRemote() {
     if (_issueNumber == null) {
@@ -95,6 +90,7 @@ class Task {
           title: title,
           body: description,
           labels: labels.map((final label) => label.name).toList(),
+          state: state,
         ),
       )
       .then((final issue) {
@@ -110,6 +106,7 @@ class Task {
           title: title,
           body: description,
           labels: labels.map((final label) => label.name).toList(),
+          state: state,
         ),
       )
       .then((final issue) {
@@ -127,6 +124,7 @@ class Task {
     closedAt: closedAt,
     slug: _slug,
     issueNumber: _issueNumber,
+    state: state,
   );
 
   /// Replaces the current instance with the values from another to do instance.
@@ -136,6 +134,7 @@ class Task {
     labels = List<IssueLabel>.from(update.labels);
     updatedAt = update.updatedAt;
     closedAt = update.closedAt;
+    state = update.state;
   }
 
   @override

--- a/lib/core/models/task.dart
+++ b/lib/core/models/task.dart
@@ -12,7 +12,9 @@ class Task {
     required final slug,
     required this.createdAt,
     required this.updatedAt,
+    this.state = "open",
     this.closedAt,
+    this.stateReason,
     final issueNumber,
   }) : _slug = slug,
        _issueNumber = issueNumber;
@@ -25,7 +27,9 @@ class Task {
       updatedAt = issue.updatedAt!,
       closedAt = issue.closedAt,
       labels = issue.labels,
-      _issueNumber = issue.number;
+      _issueNumber = issue.number,
+      state = issue.state,
+      stateReason = issue.stateReason;
 
   /// Creates an empty task with the given [slug].
   Task.createEmpty(final RepositorySlug slug)
@@ -36,7 +40,8 @@ class Task {
       updatedAt = DateTime.now(),
       closedAt = null,
       _slug = slug,
-      _issueNumber = null;
+      _issueNumber = null,
+      state = "open";
 
   static const _classId = "com.GitDone.gitdone.core.models.task";
 
@@ -65,6 +70,12 @@ class Task {
   /// The unique identifier for the issue in the repository, if applicable.
   int? get issueNumber => _issueNumber;
   final int? _issueNumber;
+
+  /// The state of the task, e.g., "OPEN" or "CLOSED".
+  String state;
+
+  /// The reason for the current state of the task, if applicable.
+  String? stateReason;
 
   /// Saves the current task to the remote repository.
   Future<Task> saveRemote() {

--- a/lib/core/models/task.dart
+++ b/lib/core/models/task.dart
@@ -69,7 +69,7 @@ class Task {
   int? get issueNumber => _issueNumber;
   final int? _issueNumber;
 
-  /// The state of the task, e.g., "OPEN" or "CLOSED".
+  /// The state of the task, e.g., "open" or "closed".
   String state;
 
   /// Saves the current task to the remote repository.

--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -134,4 +134,71 @@ class TaskHandler extends ChangeNotifier {
     }
     return null;
   }
+
+  /// Marks a task as done by updating its state to "CLOSED" and setting the closedAt timestamp.
+  Future<Task> updateIssueState(
+    final Task task,
+    final IssueState newState, {
+    final StateReason reason = StateReason.noReason,
+  }) async {
+    Logger.log(
+      "Marking task as ${newState.value}: ${task.title}",
+      _classId,
+      LogLevel.detailed,
+    );
+
+    task
+      ..state = newState.value
+      ..stateReason = reason.value
+      ..closedAt = newState == IssueState.closed
+          ? DateTime.now().toUtc()
+          : task.closedAt
+      ..updatedAt = DateTime.now().toUtc()
+      ..saveRemote();
+
+    print("Task updated: ${task.title}, State: ${task.state}");
+    print("Closed at: ${task.closedAt}, Updated at: ${task.updatedAt}");
+    print("State reason: ${task.stateReason}");
+
+    return task;
+  }
+}
+
+/// Enum representing the state of an issue in a repository.
+enum IssueState {
+  /// The issue is open and active.
+  open("open"),
+
+  /// The issue is closed and inactive.
+  closed("close");
+
+  const IssueState(this._value);
+  final String _value;
+
+  /// Returns the string representation of the issue state.
+  String get value => _value;
+}
+
+/// Enum representing the reason for the state of an issue in a repository.
+enum StateReason {
+  /// The issue is completed.
+  completed("completed"),
+
+  /// The issue is not planned.
+  notPlanned("not_planned"),
+
+  /// The issue is a duplicate of another issue.
+  duplicate("duplicate"),
+
+  /// The issue is invalid.
+  reopened("reopened"),
+
+  /// The issue is not relevant.
+  noReason(null);
+
+  const StateReason(this._value);
+  final String? _value;
+
+  /// Returns the string representation of the state reason.
+  String? get value => _value;
 }

--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -185,4 +185,14 @@ enum IssueState {
 
   /// Returns the string representation of the issue state.
   String get value => _value;
+
+  /// Returns the IssueState corresponding to the given string value.
+  static IssueState fromValue(final String value) {
+    for (final IssueState state in IssueState.values) {
+      if (state.value == value) {
+        return state;
+      }
+    }
+    throw ArgumentError("Illegal value: $value");
+  }
 }

--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -178,7 +178,7 @@ enum IssueState {
   open("open"),
 
   /// The issue is closed and inactive.
-  closed("close");
+  closed("closed");
 
   const IssueState(this._value);
   final String _value;

--- a/lib/core/task_handler.dart
+++ b/lib/core/task_handler.dart
@@ -135,7 +135,7 @@ class TaskHandler extends ChangeNotifier {
     return null;
   }
 
-  /// Marks a task as done by updating its state to "CLOSED" and setting the closedAt timestamp.
+  /// Marks a task as done by updating its state to "closed" and setting the closedAt timestamp.
   Future<Task> updateIssueState(
     final Task task,
     final IssueState newState,

--- a/lib/ui/task_details/task_details_view.dart
+++ b/lib/ui/task_details/task_details_view.dart
@@ -10,6 +10,7 @@ import "package:gitdone/ui/_widgets/task_labels.dart";
 import "package:gitdone/ui/task_edit/task_edit_view.dart";
 import "package:intl/intl.dart";
 import "package:markdown_widget/markdown_widget.dart";
+import "package:provider/provider.dart";
 
 /// A widget that displays a card for a task item.
 class TaskDetailsView extends StatefulWidget {
@@ -34,43 +35,48 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
       "com.GitDone.gitdone.ui.task_details.task_details_view_model";
 
   @override
-  Widget build(final BuildContext context) => Scaffold(
-    appBar: const NormalAppBar(),
-    body: SingleChildScrollView(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _renderTitle(),
-          _renderLabels(),
-          const Padding(padding: EdgeInsets.all(8)),
-          _renderDescription(),
-          const Padding(padding: EdgeInsets.all(8)),
-          _renderStatus(),
-          const Padding(padding: EdgeInsets.all(8)),
-        ],
+  Widget build(final BuildContext context) => ChangeNotifierProvider(
+    create: (_) => _TaskDetailsViewViewModel(widget.task),
+    child: Scaffold(
+      appBar: const NormalAppBar(),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _renderTitle(),
+            _renderLabels(),
+            const Padding(padding: EdgeInsets.all(8)),
+            _renderDescription(),
+            const Padding(padding: EdgeInsets.all(8)),
+            _renderStatus(),
+            const Padding(padding: EdgeInsets.all(8)),
+          ],
+        ),
       ),
-    ),
-    floatingActionButton: Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        FloatingActionButton.small(
-          heroTag: "markTask",
-          onPressed: widget.task.state == IssueState.open.value
-              ? _markTaskAsDone
-              : _markTaskAsOpen,
-          child: widget.task.state == IssueState.open.value
-              ? const Icon(Icons.done)
-              : const Icon(Icons.undo),
+      floatingActionButton: Consumer<_TaskDetailsViewViewModel>(
+        builder: (final context, final viewModel, _) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            FloatingActionButton.small(
+              heroTag: "markTask",
+              onPressed: viewModel.task.state == IssueState.open.value
+                  ? viewModel._markTaskAsDone
+                  : viewModel._markTaskAsOpen,
+              child: viewModel.task.state == IssueState.open.value
+                  ? const Icon(Icons.done)
+                  : const Icon(Icons.undo),
+            ),
+            FloatingActionButton(
+              heroTag: "editTask",
+              onPressed: _editTask,
+              child: const Icon(Icons.edit),
+            ),
+          ],
         ),
-        FloatingActionButton(
-          heroTag: "editTask",
-          onPressed: _editTask,
-          child: const Icon(Icons.edit),
-        ),
-      ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     ),
-    floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
   );
 
   Widget _renderTitle() => PageTitleWidget(title: widget.task.title);
@@ -112,18 +118,6 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
     ),
   );
 
-  Future<void> _markTaskAsDone() async {
-    await TaskHandler().updateIssueState(
-      widget.task,
-      IssueState.closed,
-      reason: StateReason.completed,
-    );
-  }
-
-  Future<void> _markTaskAsOpen() async {
-    await TaskHandler().updateIssueState(widget.task, IssueState.open);
-  }
-
   Future<void> _editTask() async {
     Logger.log("Edit task: ${widget.task.title}", _classId, LogLevel.detailed);
     final Task? updated = await Navigation.navigate(TaskEditView(widget.task));
@@ -143,4 +137,30 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
 
   String _formatDateTime(final DateTime dateTime) =>
       DateFormat("yyyy-MM-dd HH:mm:ss").format(dateTime.toLocal());
+}
+
+class _TaskDetailsViewViewModel extends ChangeNotifier {
+  _TaskDetailsViewViewModel(this._task) {
+    Logger.log(
+      "Initialized TaskDetailsViewModel for task: ${_task.title}",
+      _classId,
+      LogLevel.detailed,
+    );
+  }
+  static const _classId =
+      "com.GitDone.gitdone.ui.task_details.task_details_view_view_model";
+
+  Task _task;
+
+  Task get task => _task;
+
+  Future<void> _markTaskAsDone() async {
+    _task = await TaskHandler().updateIssueState(_task, IssueState.closed);
+    notifyListeners();
+  }
+
+  Future<void> _markTaskAsOpen() async {
+    _task = await TaskHandler().updateIssueState(_task, IssueState.open);
+    notifyListeners();
+  }
 }

--- a/lib/ui/task_details/task_details_view.dart
+++ b/lib/ui/task_details/task_details_view.dart
@@ -1,6 +1,7 @@
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:gitdone/core/models/task.dart";
+import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/core/utils/logger.dart";
 import "package:gitdone/core/utils/navigation.dart";
 import "package:gitdone/ui/_widgets/app_bar.dart";
@@ -50,9 +51,24 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
         ],
       ),
     ),
-    floatingActionButton: FloatingActionButton(
-      onPressed: _editTask,
-      child: const Icon(Icons.edit),
+    floatingActionButton: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        FloatingActionButton.small(
+          heroTag: "markTask",
+          onPressed: widget.task.state == IssueState.open.value
+              ? _markTaskAsDone
+              : _markTaskAsOpen,
+          child: widget.task.state == IssueState.open.value
+              ? const Icon(Icons.done)
+              : const Icon(Icons.undo),
+        ),
+        FloatingActionButton(
+          heroTag: "editTask",
+          onPressed: _editTask,
+          child: const Icon(Icons.edit),
+        ),
+      ],
     ),
     floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
   );
@@ -95,6 +111,18 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
       ],
     ),
   );
+
+  Future<void> _markTaskAsDone() async {
+    await TaskHandler().updateIssueState(
+      widget.task,
+      IssueState.closed,
+      reason: StateReason.completed,
+    );
+  }
+
+  Future<void> _markTaskAsOpen() async {
+    await TaskHandler().updateIssueState(widget.task, IssueState.open);
+  }
 
   Future<void> _editTask() async {
     Logger.log("Edit task: ${widget.task.title}", _classId, LogLevel.detailed);

--- a/lib/ui/task_list/task_list_view.dart
+++ b/lib/ui/task_list/task_list_view.dart
@@ -1,4 +1,6 @@
 import "package:flutter/material.dart";
+import "package:gitdone/core/task_handler.dart";
+import "package:gitdone/core/theme/app_color.dart";
 import "package:gitdone/ui/_widgets/filter_chip/filter_chip_dropdown.dart";
 import "package:gitdone/ui/_widgets/filter_chip/filter_chip_item.dart";
 import "package:gitdone/ui/_widgets/task_card.dart";
@@ -142,7 +144,32 @@ class _TaskListViewState extends State<TaskListView> {
           shrinkWrap: true,
           physics: const AlwaysScrollableScrollPhysics(),
           children: model.tasks
-              .map((final task) => TaskCard(task: task))
+              .map(
+                (final task) => task.state == IssueState.open.value
+                    ? Dismissible(
+                        key: ValueKey(task.issueNumber),
+                        direction: DismissDirection.startToEnd,
+                        background: Container(
+                          color: AppColor.colorScheme.primary,
+                          alignment: Alignment.centerRight,
+                          padding: const EdgeInsets.symmetric(horizontal: 20),
+                          child: const Row(
+                            children: [
+                              Text("Mark as done"),
+                              Icon(Icons.done, color: Colors.white),
+                            ],
+                          ),
+                        ),
+                        onDismissed: (_) {
+                          TaskHandler().updateIssueState(
+                            task,
+                            IssueState.closed,
+                          );
+                        },
+                        child: TaskCard(task: task),
+                      )
+                    : TaskCard(task: task),
+              )
               .toList(),
         ),
       ),


### PR DESCRIPTION
This pull request introduces a new way to manage the state of tasks (open or closed) in the codebase, adds supporting logic for updating task state, and enhances the UI to allow users to mark tasks as done or reopen them. The changes are grouped into model updates, business logic enhancements, and UI improvements.

**Task State Management Enhancements**

_Model updates:_
* Added a `state` property to the `Task` model to track whether a task is "open" or "closed", including logic to initialize, update, and serialize this property. [[1]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22R15) [[2]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22L28-R30) [[3]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22L39-R42) [[4]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22R72-R74) [[5]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22R93) [[6]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22R109) [[7]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22R127) [[8]](diffhunk://#diff-4e87d0725a05cf49d5565fb95216051d77e68aa58277dd832adeaaffb7d74c22R137)

_Business logic enhancements:_
* Introduced an `IssueState` enum to represent possible task states and added the `updateIssueState` method in `TaskHandler` to update a task's state and timestamps, notify listeners, and handle persistence.

_UI improvements:_
* Updated the `TaskDetailsView` to use a view model (`_TaskDetailsViewViewModel`) with provider/consumer pattern, enabling the UI to reactively display and update task state. Added buttons to mark a task as done or reopen it, with appropriate icons and actions. [[1]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370R4) [[2]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370R13) [[3]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370L36-R40) [[4]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370L53-R79) [[5]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370R141-R166)