### PR TITLE
🔧 Update reviewers to new gitdone development team

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   "major": {
     "automerge": false
   },
-  "reviewers": ["team:development"],
+  "reviewers": ["team:gitdone-development"],
   "labels": [
     "📌 Dependencies"
   ],


### PR DESCRIPTION
This pull request makes a minor update to the Renovate configuration by changing the assigned reviewer team.

* Changed the `reviewers` field in `.github/renovate.json` from `"team:development"` to `"team:gitdone-development"` to ensure pull requests are reviewed by the correct team.