### PR TITLE
⬆️ Update Flutter version to 3.35.0

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   FLUTTER_CHANNEL: stable
-  FLUTTER_VERSION: 3.32.0
+  FLUTTER_VERSION: 3.35.0
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the Flutter version used in the GitHub Actions workflow to ensure the project builds and tests against the latest stable release.

Dependency update:

* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL11-R11): Updated the `FLUTTER_VERSION` from `3.32.0` to `3.35.0` to use the latest stable Flutter version in CI workflows.