### PR TITLE
🔧 Update renovate.json to use base config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,32 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json"
   ],
-  "major": {
-    "automerge": false
-  },
   "reviewers": ["team:gitdone-development"],
-  "labels": [
-    "📌 Dependencies"
-  ],
-  "commitMessagePrefix": "⬆️",
-  "commitMessageAction": "Upgrade",
   "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "pin"
-      ],
-      "commitMessagePrefix": "📌",
-      "commitMessageAction": "Pin"
-    },
-    {
-      "matchUpdateTypes": [
-        "rollback"
-      ],
-      "commitMessagePrefix": "⬇️",
-      "commitMessageAction": "Downgrade"
-    },
     {
       "matchPackageNames": [
         "dev.flutter.flutter-plugin-loader",
@@ -35,9 +13,5 @@
       ],
       "enabled": false
     }
-  ],
-  "dependencyDashboardTitle": "📌 Dependency Dashboard",
-  "dependencyDashboardLabels": [
-    "📌 Dependencies"
   ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to use a shared configuration file and removes several custom rules and settings, streamlining the dependency update process.

Renovate configuration changes:

* Switched the `extends` field to use the shared RubberDuckCrew Renovate config instead of the default recommended config, centralizing configuration management.
* Removed custom settings for major updates, reviewers, labels, commit message formatting, and dependency dashboard configuration to rely on the shared config defaults. [[1]](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L4-L29) [[2]](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L38-L41)
* Cleaned up `packageRules` by removing rules for pinning and rolling back dependencies, leaving only the rule for disabling updates to `dev.flutter.flutter-plugin-loader`.