### PR TITLE
👷Size analysis with workflow dispatch

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -66,7 +66,7 @@ jobs:
     needs: test
     if: ${{ ( startsWith(github.ref, 'refs/tags/')
         || contains(github.event.pull_request.labels.*.name, '⚗️ Request Build')
-        || inputs.type == 'build' || inputs.type == 'size-analysis' )
+        || inputs.build-type == 'build' || inputs.build-type == 'size-analysis' )
         && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
 
@@ -141,7 +141,7 @@ jobs:
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
       - name: Build APK for size analysis
-        if: inputs.type != 'size-analysis'
+        if: inputs.build-type != 'size-analysis'
         run: flutter build apk ${{ steps.build_options.outputs.build_args }} --analyze-size --target-platform android-arm64
 
       - name: Rename APK & App Bundle
@@ -169,7 +169,7 @@ jobs:
           path: app/build/app/symbols
 
       - name: Upload size analysis apk
-        if: inputs.type != 'size-analysis'
+        if: inputs.build-type != 'size-analysis'
         uses: actions/upload-artifact@v4
         with:
           name: Size Analysis APK ARM64


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/test-build-release.yml` to improve flexibility and control over build and analysis jobs. The most significant changes include adding workflow dispatch support with custom build types, refining job conditionals, and adjusting label handling.

**Workflow enhancements:**

* Added `workflow_dispatch` support with a new `build-type` input, allowing manual triggering of the workflow and selection between `test`, `build`, and `size-analysis` options.

**Job conditional logic improvements:**

* Updated the build job's conditional to also trigger on manual dispatch for `build` or `size-analysis` types, in addition to existing triggers.
* Changed the condition for building the APK for size analysis and uploading the artifact to use the workflow input instead of pull request labels, making manual runs more consistent. [[1]](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL125-R139) [[2]](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL153-R167)

**Label management:**

* Simplified label removal to only remove the `⚗️ Request Build` label, instead of both build and size analysis labels, reflecting the new workflow logic.