### PR TITLE
👷 Fix enforce branch names inputs

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -29,14 +29,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout branches.yml
-        uses: actions/checkout@v5
-        with:
-          sparse-checkout: .github/branches.yml
-          sparse-checkout-cone-mode: false
-
       - name: Enforce pull request branch names
         uses: IamPekka058/branchMatchRegex@v1
         with:
-          inputPath: https://raw.githubusercontent.com/RubberDuckCrew/.github/refs/heads/main/configs/conventions/branches.yml
+          path: https://raw.githubusercontent.com/RubberDuckCrew/.github/refs/heads/main/configs/conventions/branches.yml
           useWildcard: true


### PR DESCRIPTION
This pull request makes a minor update to the branch name enforcement workflow configuration. The main change is a small adjustment to the input parameter name for the branch naming convention check.

* Changed the parameter from `inputPath` to `path` for the `IamPekka058/branchMatchRegex@v1` action in `.github/workflows/conventions.yml` to match the expected input name.