### PR TITLE
:bug:  Fix condition for APK build in workflow

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -141,7 +141,7 @@ jobs:
         run: flutter build appbundle ${{ steps.build_options.outputs.build_args }}
 
       - name: Build APK for size analysis
-        if: inputs.build-type != 'size-analysis'
+        if: inputs.build-type == 'size-analysis'
         run: flutter build apk ${{ steps.build_options.outputs.build_args }} --analyze-size --target-platform android-arm64
 
       - name: Rename APK & App Bundle


### PR DESCRIPTION
This pull request corrects the conditional logic for building APKs for size analysis in the GitHub Actions workflow. The change ensures that the APK is only built for size analysis when the appropriate input is provided.

Workflow logic fix:

* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL144-R144): Changed the condition for the "Build APK for size analysis" step to run only when `inputs.build-type` is `'size-analysis'`, fixing a logic error that previously prevented the step from running as intended.