### PR TITLE
:arrow_up: Update Vite dependency to version 5.4.20

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2370,9 +2370,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+            "version": "5.4.20",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+            "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,6 +22,7 @@
         "vitepress": "^1.6.4"
     },
     "overrides": {
-        "esbuild": "^0.25.0"
+        "esbuild": "^0.25.0",
+        "vite": "^5.4.20"
     }
 }


### PR DESCRIPTION
This pull request updates the `vite` dependency in the documentation package to the latest patch version, ensuring compatibility and incorporating the latest fixes.

Dependency updates:

* Updated `vite` from version `5.4.19` to `5.4.20` in `docs/package-lock.json` to include the latest patch and integrity hash.
* Added an override for `vite` at version `^5.4.20` in `docs/package.json` to enforce usage of the latest patch version.