### PR TITLE
👷 Fix artifact names in post tagged

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -207,12 +207,17 @@ jobs:
       - name: Download APK artifact
         uses: actions/download-artifact@v5
         with:
-          name: GitDone_${{ needs.build.outputs.version_name }}.apk
+          name: GitDone ${{ needs.build.outputs.version_name }} APK
 
       - name: Download app bundle artifact
         uses: actions/download-artifact@v5
         with:
-          name: GitDone_${{ needs.build.outputs.version_name }}.aab
+          name: GitDone ${{ needs.build.outputs.version_name }} AAB
+
+      - name: Download symbols artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: GitDone ${{ needs.build.outputs.version_name }} Symbols
 
       - name: Release artifacts
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -214,11 +214,6 @@ jobs:
         with:
           name: GitDone ${{ needs.build.outputs.version_name }} AAB
 
-      - name: Download symbols artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: GitDone ${{ needs.build.outputs.version_name }} Symbols
-
       - name: Release artifacts
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request updates the artifact naming conventions in the GitHub Actions workflow for test, build, and release. The changes make artifact names more readable and add support for downloading symbols artifacts.

Artifact naming improvements:

* Updated the artifact names for APK and AAB files to use spaces and clearer labels, changing from `GitDone_${{ needs.build.outputs.version_name }}.apk` to `GitDone ${{ needs.build.outputs.version_name }} APK` and from `GitDone_${{ needs.build.outputs.version_name }}.aab` to `GitDone ${{ needs.build.outputs.version_name }} AAB`.

Symbols artifact support:

* Added a new step to download the symbols artifact, using the name `GitDone ${{ needs.build.outputs.version_name }} Symbols`.