### PR TITLE
👷 Add permissions for contents in release workflow

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -203,6 +203,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Download APK artifact
         uses: actions/download-artifact@v5


### PR DESCRIPTION
This pull request adds a permissions block to the GitHub Actions workflow for building and releasing. This change ensures that the workflow has the necessary permissions to write to repository contents during the release process. 

* Added `permissions: contents: write` to the `jobs:` section of `.github/workflows/test-build-release.yml` to allow the workflow to write to repository contents.