### PR TITLE
:construction_worker: Update artifact upload path in release workflow

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -227,7 +227,6 @@ jobs:
 
       - name: Zip symbols folder
         run: |
-          cd build-artifacts
           zip -r "GitDone_${{ needs.build.outputs.version_name }}_Symbols.zip" symbols
 
       - name: Release artifacts


### PR DESCRIPTION
This pull request updates the build and release workflow in `.github/workflows/test-build-release.yml` to improve handling of symbol files generated during the build process. The main changes streamline the management, packaging, and release of debug symbols alongside the APK and AAB artifacts.

**Symbol file management and release:**

* The symbols folder is now moved to the `build-artifacts` directory after the build, ensuring all artifacts are stored together for easier access and management.
* The upload step for the symbols artifact now points to `build-artifacts/symbols` instead of the previous location, aligning with the new artifact structure.
* During the release phase, the symbols artifact is downloaded and then zipped as `symbols.zip` in the `build-artifacts` directory, preparing it for distribution.
* The zipped symbols file (`symbols.zip`) is now included in the release artifacts alongside the APK and AAB files, making it available for debugging and analysis post-release.

**Build argument formatting:**

* The formatting of the `build_args` output has been cleaned up for consistency, consolidating the arguments into a single line.