### PR TITLE
👷 Update path of zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="assets/icons/app/gitdone.svg" alt="gitdone logo" width="150"/>
   <br><br>
-  <a href="https://github.com/RubberDuckCrew/gitdone/releases" target="_blank"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/RubberDuckCrew/gitdone"></a>
+  <a href="https://github.com/RubberDuckCrew/gitdone/releases" target="_blank"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/RubberDuckCrew/gitdone?include_prereleases"></a>
   <img alt="GitHub Downloads (all assets, all releases)" src="https://img.shields.io/github/downloads/RubberDuckCrew/gitdone/total">
   <a href="https://github.com/RubberDuckCrew/gitdone/actions/workflows/test-build-release.yml" target="_blank"><img alt="GitHub Pipeline" src="https://github.com/RubberDuckCrew/gitdone/actions/workflows/test-build-release.yml/badge.svg"></a>
 </div>


### PR DESCRIPTION
This pull request makes a minor update to the artifact zipping step in the GitHub Actions workflow. The change modifies the command to zip only files matching the `*.symbols` pattern instead of the entire `symbols` folder.

* Changed the `zip` command in `.github/workflows/test-build-release.yml` to only include files matching `*.symbols` instead of zipping the whole `symbols` directory.