### PR TITLE
👷 Fix flavor on tagged build

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -122,11 +122,7 @@ jobs:
           SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           SHORT_SHA="${SHA:0:7}"
           VERSION_NAME="$(echo "$GITHUB_REF_NAME" | tr / _)_$SHORT_SHA"
-          if [[ "${GITHUB_REF}" == 'refs/tags/*' ]]; then
-            FLAVOR="production"
-          else
-            FLAVOR="staging"
-          fi
+          FLAVOR="${{ startsWith(github.ref, 'refs/tags/') && 'production' || 'staging' }}"
           {
             echo "flavor=$FLAVOR"
             echo "version_name=$VERSION_NAME"


### PR DESCRIPTION
This pull request updates the logic for determining the build flavor in the GitHub Actions workflow configuration. The change simplifies how the `FLAVOR` variable is set, using a more concise syntax.

Workflow configuration improvement:

* [`.github/workflows/test-build-release.yml`](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL125-R125): Replaced the shell conditional block with a single expression using GitHub Actions' `startsWith` function to set the `FLAVOR` variable to either `production` or `staging`.