### PR TITLE
:arrow_up: Bump/Pin dependencies and update Flutter SDK version

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   FLUTTER_CHANNEL: stable
-  FLUTTER_VERSION: 3.35.0
+  FLUTTER_VERSION: 3.35.3
 
 jobs:
   test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -178,10 +178,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -299,10 +299,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_parser:
     dependency: transitive
     description:
@@ -379,10 +379,10 @@ packages:
     dependency: "direct main"
     description:
       name: markdown_widget
-      sha256: b52c13d3ee4d0e60c812e15b0593f142a3b8a2003cde1babb271d001a1dbdc1c
+      sha256: e815fd1f7a8d533fb83be18c2ad1cd83169fcbe9d3c9ffe8fc96c473d01f44e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2+8"
+    version: "2.3.2"
   matcher:
     dependency: transitive
     description:
@@ -443,18 +443,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "9.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -877,5 +877,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: "3.9.2"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0-alpha
 
 environment:
-  sdk: ^3.8.0
+  sdk: 3.9.2
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -33,33 +33,33 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
-  flutter_secure_storage: ^9.2.4
-  http: ^1.3.0
-  provider: ^6.1.2
-  url_launcher: ^6.3.1
-  flutter_svg: ^2.0.17
+  cupertino_icons: 1.0.8
+  flutter_secure_storage: 9.2.4
+  http: 1.5.0
+  provider: 6.1.5
+  url_launcher: 6.3.2
+  flutter_svg: 2.2.1
   github_flutter:
     path: ../github_flutter
-  shared_preferences: ^2.5.3
-  package_info_plus: ^9.0.0
-  markdown_widget: ^2.3.2+8
-  intl: ^0.20.2
-  crypto: ^3.0.2
-  flutter_web_auth_2: ^4.1.0
-  multi_dropdown: ^3.0.1
+  shared_preferences: 2.5.3
+  package_info_plus: 9.0.0
+  markdown_widget: 2.3.2
+  intl: 0.20.2
+  crypto: 3.0.6
+  flutter_web_auth_2: 4.1.0
+  multi_dropdown: 3.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mocktail: ^1.0.4
+  mocktail: 1.0.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^6.0.0
+  flutter_lints: 6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
This pull request updates the project to use newer versions of Flutter and Dart, and aligns package dependencies to their latest releases by removing caret (`^`) version constraints and bumping some package versions. These changes help ensure compatibility with the latest SDKs and improve overall stability.

**SDK and Environment Updates:**
* Updated the Flutter version to `3.35.3` in `.github/workflows/test-build-release.yml` to use the latest stable release.
* Updated the Dart SDK requirement to `3.9.2` in `pubspec.yaml` to match the latest language features and improvements.

**Dependency Management:**
* Removed caret (`^`) version constraints from all dependencies and dev_dependencies in `pubspec.yaml`, ensuring exact versions are used for more predictable builds.
* Updated several dependencies to newer versions, including `http`, `provider`, `url_launcher`, `flutter_svg`, and `crypto` for improved functionality and compatibility.
* Applied the same exact versioning approach to dev dependencies like `mocktail` and `flutter_lints` for consistency.