### PR TITLE
🔧 Move flutter version from actions to pubspec.yaml

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -17,10 +17,6 @@ on:
           - build
           - size-analysis
 
-env:
-  FLUTTER_CHANNEL: stable
-  FLUTTER_VERSION: 3.35.3
-
 jobs:
   test:
     name: Format, analyze and test
@@ -45,8 +41,6 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
-          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
       - name: Install pub dependencies
@@ -91,8 +85,6 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
-          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
       - name: Set up JDK

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: graphql
-      sha256: "735bbbaa4db10d38054932e726d291bdd46e46e0575cd482a74b0615b8622e1c"
+      sha256: "2011435a7fea92fff5b02c77550a54f89427a3c33c92cd2fccfd3aa87ed3727d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "5.2.2"
   highlight:
     dependency: transitive
     description:
@@ -878,4 +878,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.9.2"
-  flutter: ">=3.29.0"
+  flutter: "3.35.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ version: 1.0.0-alpha
 
 environment:
   sdk: 3.9.2
+  flutter: 3.35.3
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
This pull request updates the project configuration to specify the Flutter version directly in `pubspec.yaml` instead of using environment variables in the GitHub Actions workflow. The workflow steps for setting up Flutter have been simplified by removing references to those environment variables.

**Configuration updates:**

* Added an explicit `flutter: 3.35.3` entry to the `environment` section in `pubspec.yaml`, ensuring the required Flutter version is clearly specified in the project configuration.

**Workflow simplification:**

* Removed the `FLUTTER_CHANNEL` and `FLUTTER_VERSION` environment variables from `.github/workflows/test-build-release.yml`.
* Updated the workflow steps for setting up Flutter by eliminating the use of the removed environment variables, simplifying the configuration for both `test` and `build_release` jobs. [[1]](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL48-L49) [[2]](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eL94-L95)