### PR TITLE
👷 Add concurrency to test-build-release workflow

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -18,7 +18,7 @@ on:
           - size-analysis
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This pull request introduces a small but important update to the GitHub Actions workflow configuration. The change adds a concurrency group to the `.github/workflows/test-build-release.yml` file to ensure that only one workflow run per pull request or branch is active at a time, automatically cancelling any in-progress runs for the same group.

* Added a `concurrency` configuration to the workflow to prevent multiple simultaneous runs for the same pull request or branch, improving CI efficiency and reducing resource usage.