### PR TITLE
:arrow_up: Upgrade Flutter SDK version to 3.35.4

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -878,4 +878,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: "3.9.2"
-  flutter: "3.35.3"
+  flutter: "3.35.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ version: 1.0.0-alpha
 
 environment:
   sdk: 3.9.2
-  flutter: 3.35.3
+  flutter: 3.35.4
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
This pull request makes a minor update to the Flutter SDK version in the `pubspec.yaml` file, upgrading from version 3.35.3 to 3.35.4. This change ensures compatibility with the latest Flutter release.

* Upgraded the Flutter SDK version from `3.35.3` to `3.35.4` in `pubspec.yaml` to maintain up-to-date dependencies.