### PR TITLE
:construction_worker: Add Dart SDK synchronization step

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           cache: true
 
+      - name: Sync Dart SDK version
+        uses: IamPekka058/flutter-dart-sync@v0
+        with:
+          pubspec_path: ./pubspec.yaml
+
       - name: Install pub dependencies
         run: flutter pub get
 
@@ -78,6 +83,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           cache: true
+
+      - name: Sync Dart SDK version
+        uses: IamPekka058/flutter-dart-sync@v0
+        with:
+          pubspec_path: ./pubspec.yaml
 
       - name: Set up JDK
         uses: actions/setup-java@v5


### PR DESCRIPTION
This pull request updates the CI workflow configuration to ensure the Dart SDK version is kept in sync with the project's requirements. The main change is the addition of a step using the `flutter-dart-sync` GitHub action, which reads the Dart SDK version from `pubspec.yaml` and aligns the workflow environment accordingly.

Workflow configuration improvements:

* Added a `Sync Dart SDK version` step to the CI workflow, utilizing the `IamPekka058/flutter-dart-sync@v0` action to automatically synchronize the Dart SDK version based on the `pubspec.yaml` file. [[1]](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR44-R48) [[2]](diffhunk://#diff-612b63199ed131209fb2aaed52e21f4112e794dbd4d750fdf52aaff72ac9ca7eR87-R91)