### PR TITLE
:bug: Fix slowly loading task list when navigating from settings page

### DIFF
--- a/lib/ui/main_screen.dart
+++ b/lib/ui/main_screen.dart
@@ -20,11 +20,10 @@ class _MainScreenState extends State<MainScreen> {
     child: Consumer<MainScreenViewModel>(
       builder: (final context, final viewModel, final child) => Scaffold(
         appBar: const NormalAppBar(),
-        body: switch (viewModel.selectedIndex) {
-          0 => const TaskListView(),
-          1 => const SettingsView(),
-          _ => const TaskListView(),
-        },
+        body: IndexedStack(
+          index: viewModel.selectedIndex,
+          children: const [TaskListView(), SettingsView()],
+        ),
         bottomNavigationBar: NavigationBar(
           destinations: const [
             NavigationDestination(icon: Icon(Icons.inbox), label: "Todos"),

--- a/lib/ui/settings/widgets/repository_selector/repository_selector_view_model.dart
+++ b/lib/ui/settings/widgets/repository_selector/repository_selector_view_model.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:gitdone/core/models/repository_details.dart";
+import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/ui/settings/widgets/repository_selector/repository_selector_model.dart";
 
 /// ViewModel for managing the state of the repository selector widget.
@@ -11,6 +12,7 @@ class RepositorySelectorViewModel extends ChangeNotifier {
       ..getAllUserRepositories()
       ..loadLocalRepository();
   }
+  final TaskHandler _taskHandler = TaskHandler();
   final RepositorySelectorModel _model = RepositorySelectorModel();
 
   /// The list of repositories available for selection.
@@ -22,5 +24,8 @@ class RepositorySelectorViewModel extends ChangeNotifier {
   /// Selects a repository and saves it to local storage.
   void selectRepository(final RepositoryDetails? repo) {
     _model.selectRepository(repo);
+    _taskHandler
+      ..loadTasks()
+      ..loadLabels();
   }
 }

--- a/lib/ui/task_list/task_list_view_model.dart
+++ b/lib/ui/task_list/task_list_view_model.dart
@@ -62,7 +62,6 @@ class TaskListViewModel extends ChangeNotifier {
   /// The current sort order applied to the task list.
   String _sort = defaultSort;
   bool _isEmpty = false;
-  bool _loading = true;
 
   static const _classId =
       "com.GitDone.gitdone.ui.task_edit.task_list_view_model";
@@ -80,7 +79,7 @@ class TaskListViewModel extends ChangeNotifier {
   bool get isEmpty => _isEmpty;
 
   /// Whether the task list is currently loading.
-  bool get isLoading => _loading;
+  bool get isLoading => _taskHandler.tasksLoading;
 
   /// Returns a list of FilterChipItems for all labels, reflecting current selection state.
   List<FilterChipItem<String>> get labelFilterChipItems => allLabels.isNotEmpty
@@ -132,11 +131,8 @@ class TaskListViewModel extends ChangeNotifier {
 
   /// The current search query used to filter tasks.
   Future<void> loadTasks() async {
-    _loading = true;
-    notifyListeners();
     await _taskHandler.loadTasks();
     _isEmpty = _taskHandler.tasks.isEmpty;
-    _loading = false;
     notifyListeners();
   }
 


### PR DESCRIPTION
This pull request refactors the main screen's navigation logic to improve state retention and user experience when switching between tabs.

Closes: #263 

Navigation logic improvement:

* Replaced the use of a `switch` statement with an `IndexedStack` for rendering the main screen's body, ensuring that the state of each tab (`TaskListView` and `SettingsView`) is preserved when switching between them.