### PR TITLE
📌 Pin org workflows to v1

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   run:
-    uses: RubberDuckCrew/.github/.github/workflows/action-actionlint.yml@main
+    uses: RubberDuckCrew/.github/.github/workflows/action-actionlint.yml@v1

--- a/.github/workflows/add-project.yml
+++ b/.github/workflows/add-project.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   run:
-    uses: RubberDuckCrew/.github/.github/workflows/action-add-project.yml@main
+    uses: RubberDuckCrew/.github/.github/workflows/action-add-project.yml@v1
     secrets: inherit

--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run:
-    uses: RubberDuckCrew/.github/.github/workflows/action-close-actions.yml@main
+    uses: RubberDuckCrew/.github/.github/workflows/action-close-actions.yml@v1
     secrets: inherit
     permissions:
       issues: write

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run:
-    uses: RubberDuckCrew/.github/.github/workflows/action-conventions.yml@main
+    uses: RubberDuckCrew/.github/.github/workflows/action-conventions.yml@v1
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run:
-    uses: RubberDuckCrew/.github/.github/workflows/action-docs.yml@main
+    uses: RubberDuckCrew/.github/.github/workflows/action-docs.yml@v1
     secrets: inherit
     with:
       project-name: gitdone

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run:
-    uses: RubberDuckCrew/.github/.github/workflows/action-sync-labels.yml@main
+    uses: RubberDuckCrew/.github/.github/workflows/action-sync-labels.yml@v1
     permissions:
       issues: write
     with:


### PR DESCRIPTION
This pull request updates the workflow configuration for several GitHub Actions. The main change is switching the referenced reusable workflows from the `main` branch to the `v1` version tag, which helps ensure stability and consistency by locking to a specific version.

Workflow configuration updates:

* [`.github/workflows/actionlint.yml`](diffhunk://#diff-7ead7509c09411da47590f81c50314ace562cf4a25d49ecf60e926cb47589f9cL9-R9): Changed the reusable workflow reference from `main` to `v1` for `action-actionlint.yml`.
* [`.github/workflows/add-project.yml`](diffhunk://#diff-401123aa9766db17e238a49128b1876ab24f9281040e218afab889156ef33166L9-R9): Changed the reusable workflow reference from `main` to `v1` for `action-add-project.yml`.
* [`.github/workflows/close-actions.yml`](diffhunk://#diff-df3318838e056a0f4c9cca1f199a7fcbb200587e0529f1d21a0e1fe26c6e2243L11-R11): Changed the reusable workflow reference from `main` to `v1` for `action-close-actions.yml`.
* [`.github/workflows/conventions.yml`](diffhunk://#diff-ac2f6793cd1fb5b4ca8269805557f96b818e8e90cdd9d3e091d54d40ebd01a13L9-R9): Changed the reusable workflow reference from `main` to `v1` for `action-conventions.yml`.
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL13-R13): Changed the reusable workflow reference from `main` to `v1` for `action-docs.yml`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L10-R10): Changed the reusable workflow reference from `main` to `v1` for `action-sync-labels.yml`.