### PR TITLE
🔧 Setup renovate android ndk updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,9 @@
   "extends": [
     "github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json#v2.3.0"
   ],
-  "reviewers": ["team:gitdone-development"],
+  "reviewers": [
+    "team:gitdone-development"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [
@@ -14,5 +16,26 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "settings.gradle.kts"
+      ],
+      "matchStrings": [
+        "ndkVersion = \"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "Android NDK",
+      "datasourceTemplate": "custom.ndk"
+    }
+  ],
+  "customDatasources": {
+    "ndk": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/android/ndk/releases/latest",
+      "transformTemplates": [
+        "{\"releases\":[{\"version\":$match(body,/ndkVersion \"([^\"]+)\"/).groups[0]}],\"changelogUrl\":html_url}"
+      ]
+    }
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "settings.gradle.kts"
+        "/(^|/)build\\.gradle\\.kts$/"
       ],
       "matchStrings": [
         "ndkVersion = \"(?<currentValue>[^\"]+)\""


### PR DESCRIPTION
This pull request updates the Renovate configuration to add support for tracking the Android NDK version specified in `settings.gradle.kts` using a custom manager and datasource. The most important changes are:

**Renovate configuration enhancements:**

* Added a `customManagers` entry to detect the `ndkVersion` in `settings.gradle.kts` files using a regex, allowing Renovate to monitor and update the Android NDK version.
* Defined a `customDatasources` entry named `ndk` that fetches the latest NDK release from GitHub and extracts the version for use in Renovate updates.

**Formatting improvements:**

* Reformatted the `reviewers` field in `.github/renovate.json` for consistency, listing the reviewer on a separate line.