### PR TITLE
🔧 Extend renovate config from flutter workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,41 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json#v2.3.0"
+    "github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json#v2.3.0",
+    "github>RubberDuckCrew/flutter-workflow//renovate-flutter.json#v1.1.0",
   ],
   "reviewers": [
     "team:gitdone-development"
-  ],
-  "packageRules": [
-    {
-      "matchPackageNames": [
-        "dev.flutter.flutter-plugin-loader",
-        "dev.flutter.flutter-plugin-loader.gradle.plugin",
-        "dev.flutter.flutter-plugin-loader:dev.flutter.flutter-plugin-loader.gradle.plugin",
-        "dart"
-      ],
-      "enabled": false
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)build\\.gradle\\.kts$/"
-      ],
-      "matchStrings": [
-        "ndkVersion = \"(?<currentValue>[^\"]+)\""
-      ],
-      "depNameTemplate": "Android NDK",
-      "datasourceTemplate": "custom.ndk"
-    }
-  ],
-  "customDatasources": {
-    "ndk": {
-      "defaultRegistryUrlTemplate": "https://api.github.com/repos/android/ndk/releases/latest",
-      "transformTemplates": [
-        "{\"releases\":[{\"version\":$match(body,/ndkVersion \"([^\"]+)\"/).groups[0]}],\"changelogUrl\":html_url}"
-      ]
-    }
-  }
+  ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to better support Flutter projects and simplifies the configuration by removing custom rules and datasources that are no longer needed.

**Flutter support:**
* Added the `renovate-flutter.json` configuration from the `flutter-workflow` repository to improve Renovate support for Flutter dependencies.

**Configuration cleanup:**
* Removed custom `packageRules` that previously disabled updates for certain Flutter and Dart packages.
* Removed the custom manager and datasource for handling Android NDK version updates in `build.gradle.kts` files.