### PR TITLE
🚸 Add confirmation dialog before changing task state

### DIFF
--- a/lib/core/settings_handler.dart
+++ b/lib/core/settings_handler.dart
@@ -9,13 +9,18 @@ import "package:shared_preferences/shared_preferences.dart";
 enum SettingKey {
   /// Key for storing the selected repository details.
   selectedRepository,
+
+  /// Key for storing whether to show the confirmation dialog before marking a task as done or open.
+  showMarkTaskStateConfirmation,
 }
 
 /// Centralized handler for application settings.
 class SettingsHandler extends ChangeNotifier {
   /// Creates a new instance of [SettingsHandler].
   factory SettingsHandler() => _instance;
+
   SettingsHandler._internal();
+
   static final SettingsHandler _instance = SettingsHandler._internal();
   static const _classId = "com.GitDone.gitdone.core.settings_handler";
 
@@ -87,6 +92,20 @@ class SettingsHandler extends ChangeNotifier {
     } on Exception catch (e) {
       Logger.logError("Failed to save selected repository", _classId, e);
     }
+  }
+
+  /// Returns whether to show the confirmation dialog before marking a task as done or open.
+  bool showMarkTaskStateConfirmation() {
+    _ensurePrefsInitialized();
+    return _prefs?.getBool(SettingKey.showMarkTaskStateConfirmation.name) ??
+        true;
+  }
+
+  /// Sets whether to show the confirmation dialog before marking a task as done or open.
+  Future<void> setShowMarkTaskStateConfirmation({required bool value}) async {
+    _ensurePrefsInitialized();
+    await _prefs?.setBool(SettingKey.showMarkTaskStateConfirmation.name, value);
+    notifyListeners();
   }
 
   /// Removes the [key] setting from persistent storage.

--- a/lib/ui/_widgets/confirm_dialog.dart
+++ b/lib/ui/_widgets/confirm_dialog.dart
@@ -33,23 +33,26 @@ class ConfirmDialog extends StatelessWidget {
     actions: <Widget>[
       TextButton(
         onPressed: () {
-          Navigation.navigateBack();
-          _onConfirm();
-        },
-        child: Text(_confirmText),
-      ),
-      TextButton(
-        onPressed: () {
-          Navigation.navigateBack();
+          Navigation.navigateBack(false);
           if (_onCancel != null) _onCancel();
         },
         child: Text(_cancelText),
+      ),
+      FilledButton(
+        onPressed: () {
+          Navigation.navigateBack(true);
+          _onConfirm();
+        },
+        style: FilledButton.styleFrom(
+          padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 12),
+        ),
+        child: Text(_confirmText),
       ),
     ],
   );
 
   /// Shows the ConfirmDialog as a dialog.
-  static Future<void> show(
+  static Future<bool?> show(
     final BuildContext context, {
     required final Widget title,
     required final Widget content,
@@ -58,7 +61,7 @@ class ConfirmDialog extends StatelessWidget {
     final String cancelText = "Cancel",
     final VoidCallback? onCancel,
     final bool barrierDismissible = true,
-  }) => showDialog<void>(
+  }) => showDialog<bool>(
     context: context,
     barrierDismissible: barrierDismissible,
     builder: (final context) => ConfirmDialog(

--- a/lib/ui/_widgets/mark_task_confirmation_dialog.dart
+++ b/lib/ui/_widgets/mark_task_confirmation_dialog.dart
@@ -41,9 +41,11 @@ Future<void> showMarkTaskConfirmationDialog({
           onChanged: (final value) => setState(() => doNotAskAgain = value),
         ),
         confirmText: texts.confirmText,
-        onConfirm: () {
+        onConfirm: () async {
           if (doNotAskAgain) {
-            SettingsHandler().setShowMarkTaskStateConfirmation(value: false);
+            await SettingsHandler().setShowMarkTaskStateConfirmation(
+              value: false,
+            );
           }
           onConfirm();
         },

--- a/lib/ui/_widgets/mark_task_confirmation_dialog.dart
+++ b/lib/ui/_widgets/mark_task_confirmation_dialog.dart
@@ -1,0 +1,77 @@
+import "package:flutter/material.dart";
+import "package:gitdone/core/settings_handler.dart";
+import "package:gitdone/core/task_handler.dart";
+import "package:gitdone/ui/_widgets/confirm_dialog.dart";
+
+/// Shows a confirmation dialog for marking a task as done or open.
+///
+/// If the "don't ask again" setting is enabled, it will execute [onConfirm] immediately.
+Future<void> showMarkTaskConfirmationDialog({
+  required final BuildContext context,
+  required final String currentTaskState,
+  required final VoidCallback onConfirm,
+}) async {
+  final _DialogTexts texts = currentTaskState == IssueState.open.value
+      ? (
+          title: "Mark as done",
+          description:
+              "Are you sure you want to mark this task as done? This will close the GitHub issue.",
+          confirmText: "Mark as done",
+        )
+      : (
+          title: "Reopen task",
+          description: "Are you sure you want to reopen this task?",
+          confirmText: "Reopen",
+        );
+
+  if (!SettingsHandler().showMarkTaskStateConfirmation()) {
+    onConfirm();
+    return;
+  }
+
+  bool doNotAskAgain = false;
+  await showDialog(
+    context: context,
+    builder: (final context) => StatefulBuilder(
+      builder: (final context, final setState) => ConfirmDialog(
+        title: Text(texts.title),
+        content: _buildDialogContent(
+          description: texts.description,
+          doNotAskAgain: doNotAskAgain,
+          onChanged: (final value) => setState(() => doNotAskAgain = value),
+        ),
+        confirmText: texts.confirmText,
+        onConfirm: () {
+          if (doNotAskAgain) {
+            SettingsHandler().setShowMarkTaskStateConfirmation(value: false);
+          }
+          onConfirm();
+        },
+        cancelText: "Cancel",
+      ),
+    ),
+  );
+}
+
+Widget _buildDialogContent({
+  required final String description,
+  required final bool doNotAskAgain,
+  required final ValueChanged<bool> onChanged,
+}) => Column(
+  mainAxisSize: MainAxisSize.min,
+  crossAxisAlignment: CrossAxisAlignment.start,
+  children: [
+    Text(description),
+    Row(
+      children: [
+        Checkbox(
+          value: doNotAskAgain,
+          onChanged: (final value) => onChanged(value ?? false),
+        ),
+        const Text("Don't ask me again"),
+      ],
+    ),
+  ],
+);
+
+typedef _DialogTexts = ({String title, String description, String confirmText});

--- a/lib/ui/_widgets/task_card.dart
+++ b/lib/ui/_widgets/task_card.dart
@@ -26,31 +26,29 @@ class TaskCard extends StatefulWidget {
 
 class _TaskCardState extends State<TaskCard> {
   @override
-  Widget build(final BuildContext context) => Padding(
-    padding: const EdgeInsets.all(4),
-    child: GestureDetector(
-      onTap: () => Navigation.navigate(TaskDetailsView(widget.task)),
-      child: Card(
-        color: AppColor.colorScheme.surfaceContainer,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: Row(
-            spacing: 16,
-            children: [
-              const Placeholder(fallbackHeight: 50, fallbackWidth: 50),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  spacing: 4,
-                  children: [
-                    _buildTitle(widget.task.title),
-                    TaskLabels(widget.task),
-                  ],
-                ),
+  Widget build(final BuildContext context) => GestureDetector(
+    onTap: () => Navigation.navigate(TaskDetailsView(widget.task)),
+    child: Card(
+      color: AppColor.colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+        child: Row(
+          spacing: 16,
+          children: [
+            const Placeholder(fallbackHeight: 50, fallbackWidth: 50),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 4,
+                children: [
+                  _buildTitle(widget.task.title),
+                  TaskLabels(widget.task),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     ),

--- a/lib/ui/settings/settings_view.dart
+++ b/lib/ui/settings/settings_view.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:gitdone/app_environment.dart";
 import "package:gitdone/ui/_widgets/page_title.dart";
 import "package:gitdone/ui/settings/widgets/account_management.dart";
+import "package:gitdone/ui/settings/widgets/general_settings.dart";
 import "package:gitdone/ui/settings/widgets/import_export/import_export_settings.dart";
 import "package:gitdone/ui/settings/widgets/repository_selector/repository_selector_view.dart";
 
@@ -21,6 +22,7 @@ class SettingsView extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             spacing: 16,
             children: [
+              const GeneralSettings(),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/ui/settings/widgets/confirm_task_status_change_setting.dart
+++ b/lib/ui/settings/widgets/confirm_task_status_change_setting.dart
@@ -1,0 +1,23 @@
+import "package:flutter/material.dart";
+import "package:gitdone/core/settings_handler.dart";
+
+/// A setting widget that allows users to toggle the confirmation dialog for task status changes.
+class ConfirmTaskStatusChangeSetting extends StatelessWidget {
+  /// Creates an instance of [ConfirmTaskStatusChangeSetting].
+  const ConfirmTaskStatusChangeSetting({super.key});
+
+  @override
+  Widget build(final BuildContext context) => ListenableBuilder(
+    listenable: SettingsHandler(),
+    builder: (final context, final child) => SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      title: const Text("Confirm task status change"),
+      subtitle: const Text(
+        "Ask for confirmation before marking a task as done or reopening it.",
+      ),
+      value: SettingsHandler().showMarkTaskStateConfirmation(),
+      onChanged: (final value) =>
+          SettingsHandler().setShowMarkTaskStateConfirmation(value: value),
+    ),
+  );
+}

--- a/lib/ui/settings/widgets/general_settings.dart
+++ b/lib/ui/settings/widgets/general_settings.dart
@@ -1,0 +1,17 @@
+import "package:flutter/material.dart";
+import "package:gitdone/ui/settings/widgets/confirm_task_status_change_setting.dart";
+
+/// A widget that allows users to manage general application settings.
+class GeneralSettings extends StatelessWidget {
+  /// Creates an instance of [GeneralSettings].
+  const GeneralSettings({super.key});
+
+  @override
+  Widget build(final BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text("General Settings", style: Theme.of(context).textTheme.titleLarge),
+      const ConfirmTaskStatusChangeSetting(),
+    ],
+  );
+}

--- a/lib/ui/task_details/_widgets/task_details_floating_action_button.dart
+++ b/lib/ui/task_details/_widgets/task_details_floating_action_button.dart
@@ -1,8 +1,7 @@
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
-import "package:gitdone/core/settings_handler.dart";
 import "package:gitdone/core/task_handler.dart";
-import "package:gitdone/ui/_widgets/confirm_dialog.dart";
+import "package:gitdone/ui/_widgets/mark_task_confirmation_dialog.dart";
 import "package:gitdone/ui/task_details/task_details_view_model.dart";
 
 /// Floating action buttons for the task details view.
@@ -21,7 +20,11 @@ class TaskDetailsFloatingActionButton extends StatelessWidget {
       children: [
         FloatingActionButton.small(
           heroTag: "markTask",
-          onPressed: () => _showMarkTaskDialog(context, config),
+          onPressed: () => showMarkTaskConfirmationDialog(
+            context: context,
+            currentTaskState: viewModel.task.state,
+            onConfirm: config.onConfirm,
+          ),
           child: config.icon,
         ),
         FloatingActionButton(
@@ -35,74 +38,8 @@ class TaskDetailsFloatingActionButton extends StatelessWidget {
 
   _MarkTaskButtonConfig _markTaskButtonConfig() =>
       viewModel.task.state == IssueState.open.value
-      ? (
-          title: "Mark as done",
-          description:
-              "Are you sure you want to mark this task as done? This will close the GitHub issue.",
-          confirmText: "Mark as done",
-          onConfirm: viewModel.markTaskAsDone,
-          icon: const Icon(Icons.done),
-        )
-      : (
-          title: "Reopen task",
-          description: "Are you sure you want to reopen this task?",
-          onConfirm: viewModel.markTaskAsOpen,
-          icon: const Icon(Icons.undo),
-          confirmText: "Reopen",
-        );
-
-  Future<void> _showMarkTaskDialog(
-    final BuildContext context,
-    final _MarkTaskButtonConfig config,
-  ) async {
-    if (!SettingsHandler().showMarkTaskStateConfirmation()) {
-      config.onConfirm();
-      return;
-    }
-    bool doNotAskAgain = false;
-    await showDialog(
-      context: context,
-      builder: (final context) => StatefulBuilder(
-        builder: (final context, final setState) => ConfirmDialog(
-          title: Text(config.title),
-          content: _buildDialogContent(
-            description: config.description,
-            doNotAskAgain: doNotAskAgain,
-            onChanged: (final value) => setState(() => doNotAskAgain = value),
-          ),
-          confirmText: config.confirmText,
-          onConfirm: () {
-            if (doNotAskAgain) {
-              SettingsHandler().setShowMarkTaskStateConfirmation(value: false);
-            }
-            config.onConfirm();
-          },
-          cancelText: "Cancel",
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDialogContent({
-    required final String description,
-    required final bool doNotAskAgain,
-    required final ValueChanged<bool> onChanged,
-  }) => Column(
-    mainAxisSize: MainAxisSize.min,
-    crossAxisAlignment: CrossAxisAlignment.start,
-    children: [
-      Text(description),
-      Row(
-        children: [
-          Checkbox(
-            value: doNotAskAgain,
-            onChanged: (final value) => onChanged(value ?? false),
-          ),
-          const Text("Don't ask me again"),
-        ],
-      ),
-    ],
-  );
+      ? (onConfirm: viewModel.markTaskAsDone, icon: const Icon(Icons.done))
+      : (onConfirm: viewModel.markTaskAsOpen, icon: const Icon(Icons.undo));
 
   @override
   void debugFillProperties(final DiagnosticPropertiesBuilder properties) {
@@ -113,10 +50,4 @@ class TaskDetailsFloatingActionButton extends StatelessWidget {
   }
 }
 
-typedef _MarkTaskButtonConfig = ({
-  String confirmText,
-  String description,
-  String title,
-  VoidCallback onConfirm,
-  Icon icon,
-});
+typedef _MarkTaskButtonConfig = ({VoidCallback onConfirm, Icon icon});

--- a/lib/ui/task_details/_widgets/task_details_floating_action_button.dart
+++ b/lib/ui/task_details/_widgets/task_details_floating_action_button.dart
@@ -1,0 +1,122 @@
+import "package:flutter/foundation.dart";
+import "package:flutter/material.dart";
+import "package:gitdone/core/settings_handler.dart";
+import "package:gitdone/core/task_handler.dart";
+import "package:gitdone/ui/_widgets/confirm_dialog.dart";
+import "package:gitdone/ui/task_details/task_details_view_model.dart";
+
+/// Floating action buttons for the task details view.
+class TaskDetailsFloatingActionButton extends StatelessWidget {
+  /// Creates a [TaskDetailsFloatingActionButton] widget.
+  const TaskDetailsFloatingActionButton({required this.viewModel, super.key});
+
+  /// The view model for the task details.
+  final TaskDetailsViewModel viewModel;
+
+  @override
+  Widget build(final BuildContext context) {
+    final _MarkTaskButtonConfig config = _markTaskButtonConfig();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        FloatingActionButton.small(
+          heroTag: "markTask",
+          onPressed: () => _showMarkTaskDialog(context, config),
+          child: config.icon,
+        ),
+        FloatingActionButton(
+          heroTag: "editTask",
+          onPressed: viewModel.editTask,
+          child: const Icon(Icons.edit),
+        ),
+      ],
+    );
+  }
+
+  _MarkTaskButtonConfig _markTaskButtonConfig() =>
+      viewModel.task.state == IssueState.open.value
+      ? (
+          title: "Mark as done",
+          description:
+              "Are you sure you want to mark this task as done? This will close the GitHub issue.",
+          confirmText: "Mark as done",
+          onConfirm: viewModel.markTaskAsDone,
+          icon: const Icon(Icons.done),
+        )
+      : (
+          title: "Reopen task",
+          description: "Are you sure you want to reopen this task?",
+          onConfirm: viewModel.markTaskAsOpen,
+          icon: const Icon(Icons.undo),
+          confirmText: "Reopen",
+        );
+
+  Future<void> _showMarkTaskDialog(
+    final BuildContext context,
+    final _MarkTaskButtonConfig config,
+  ) async {
+    if (!SettingsHandler().showMarkTaskStateConfirmation()) {
+      config.onConfirm();
+      return;
+    }
+    bool doNotAskAgain = false;
+    await showDialog(
+      context: context,
+      builder: (final context) => StatefulBuilder(
+        builder: (final context, final setState) => ConfirmDialog(
+          title: Text(config.title),
+          content: _buildDialogContent(
+            description: config.description,
+            doNotAskAgain: doNotAskAgain,
+            onChanged: (final value) => setState(() => doNotAskAgain = value),
+          ),
+          confirmText: config.confirmText,
+          onConfirm: () {
+            if (doNotAskAgain) {
+              SettingsHandler().setShowMarkTaskStateConfirmation(value: false);
+            }
+            config.onConfirm();
+          },
+          cancelText: "Cancel",
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDialogContent({
+    required final String description,
+    required final bool doNotAskAgain,
+    required final ValueChanged<bool> onChanged,
+  }) => Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(description),
+      Row(
+        children: [
+          Checkbox(
+            value: doNotAskAgain,
+            onChanged: (final value) => onChanged(value ?? false),
+          ),
+          const Text("Don't ask me again"),
+        ],
+      ),
+    ],
+  );
+
+  @override
+  void debugFillProperties(final DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      DiagnosticsProperty<TaskDetailsViewModel>("viewModel", viewModel),
+    );
+  }
+}
+
+typedef _MarkTaskButtonConfig = ({
+  String confirmText,
+  String description,
+  String title,
+  VoidCallback onConfirm,
+  Icon icon,
+});

--- a/lib/ui/task_details/task_details_view.dart
+++ b/lib/ui/task_details/task_details_view.dart
@@ -1,13 +1,13 @@
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:gitdone/core/models/task.dart";
-import "package:gitdone/core/task_handler.dart";
 import "package:gitdone/core/utils/navigation.dart";
 import "package:gitdone/core/utils/snack_bar.dart";
 import "package:gitdone/ui/_widgets/app_bar.dart";
 import "package:gitdone/ui/_widgets/confirm_dialog.dart";
 import "package:gitdone/ui/_widgets/page_title.dart";
 import "package:gitdone/ui/_widgets/task_labels.dart";
+import "package:gitdone/ui/task_details/_widgets/task_details_floating_action_button.dart";
 import "package:gitdone/ui/task_details/task_details_view_model.dart";
 import "package:intl/intl.dart";
 import "package:markdown_widget/markdown_widget.dart";
@@ -53,7 +53,9 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
             ],
           ),
         ),
-        floatingActionButton: _renderFloatingActionButton(viewModel),
+        floatingActionButton: TaskDetailsFloatingActionButton(
+          viewModel: viewModel,
+        ),
         floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       ),
     ),
@@ -97,27 +99,6 @@ class _TaskDetailsViewState extends State<TaskDetailsView> {
       ],
     ),
   );
-
-  Widget _renderFloatingActionButton(final TaskDetailsViewModel viewModel) =>
-      Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          FloatingActionButton.small(
-            heroTag: "markTask",
-            onPressed: viewModel.task.state == IssueState.open.value
-                ? viewModel.markTaskAsDone
-                : viewModel.markTaskAsOpen,
-            child: viewModel.task.state == IssueState.open.value
-                ? const Icon(Icons.done)
-                : const Icon(Icons.undo),
-          ),
-          FloatingActionButton(
-            heroTag: "editTask",
-            onPressed: viewModel.editTask,
-            child: const Icon(Icons.edit),
-          ),
-        ],
-      );
 
   MenuItemButton _deleteTaskButton(final TaskDetailsViewModel viewModel) =>
       MenuItemButton(

--- a/lib/ui/task_list/_widgets/task_list_item.dart
+++ b/lib/ui/task_list/_widgets/task_list_item.dart
@@ -23,7 +23,7 @@ class TaskListItem extends StatelessWidget {
     return ClipRRect(
       borderRadius: BorderRadius.circular(12),
       child: Dismissible(
-        key: ValueKey(task.toString()),
+        key: ValueKey("${task.slug}#${task.issueNumber}"),
         direction: DismissDirection.startToEnd,
         background: Container(
           color: AppColor.colorScheme.primary,
@@ -39,16 +39,14 @@ class TaskListItem extends StatelessWidget {
           ),
         ),
         confirmDismiss: (final direction) async {
-          bool confirmed = false;
           await showMarkTaskConfirmationDialog(
             context: context,
             currentTaskState: task.state,
-            onConfirm: () => confirmed = true,
+            onConfirm: () =>
+                TaskHandler().updateIssueState(task, config.newState),
           );
-          return confirmed;
+          return false;
         },
-        onDismissed: (final direction) =>
-            TaskHandler().updateIssueState(task, config.newState),
         child: TaskCard(task: task),
       ),
     );

--- a/lib/ui/task_list/_widgets/task_list_item.dart
+++ b/lib/ui/task_list/_widgets/task_list_item.dart
@@ -20,33 +20,37 @@ class TaskListItem extends StatelessWidget {
         ? (icon: Icons.done, label: "Mark as done", newState: IssueState.closed)
         : (icon: Icons.undo, label: "Reopen task", newState: IssueState.open);
 
-    return Dismissible(
-      key: ValueKey(task.toString()),
-      direction: DismissDirection.startToEnd,
-      background: Container(
-        color: AppColor.colorScheme.primary,
-        alignment: Alignment.centerLeft,
-        padding: const EdgeInsets.symmetric(horizontal: 20),
-        child: Row(
-          children: [
-            Icon(config.icon, color: Colors.white),
-            const SizedBox(width: 8),
-            Text(config.label, style: const TextStyle(color: Colors.white)),
-          ],
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: Dismissible(
+        key: ValueKey(task.toString()),
+        direction: DismissDirection.startToEnd,
+        background: Container(
+          color: AppColor.colorScheme.primary,
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            spacing: 8,
+            children: [
+              Icon(config.icon, color: Colors.white),
+              Text(config.label, style: const TextStyle(color: Colors.white)),
+            ],
+          ),
         ),
+        confirmDismiss: (final direction) async {
+          bool confirmed = false;
+          await showMarkTaskConfirmationDialog(
+            context: context,
+            currentTaskState: task.state,
+            onConfirm: () => confirmed = true,
+          );
+          return confirmed;
+        },
+        onDismissed: (final direction) =>
+            TaskHandler().updateIssueState(task, config.newState),
+        child: TaskCard(task: task),
       ),
-      confirmDismiss: (final direction) async {
-        bool confirmed = false;
-        await showMarkTaskConfirmationDialog(
-          context: context,
-          currentTaskState: task.state,
-          onConfirm: () => confirmed = true,
-        );
-        return confirmed;
-      },
-      onDismissed: (final direction) =>
-          TaskHandler().updateIssueState(task, config.newState),
-      child: TaskCard(task: task),
     );
   }
 

--- a/lib/ui/task_list/_widgets/task_list_item.dart
+++ b/lib/ui/task_list/_widgets/task_list_item.dart
@@ -1,0 +1,60 @@
+import "package:flutter/foundation.dart";
+import "package:flutter/material.dart";
+import "package:gitdone/core/models/task.dart";
+import "package:gitdone/core/task_handler.dart";
+import "package:gitdone/core/theme/app_color.dart";
+import "package:gitdone/ui/_widgets/mark_task_confirmation_dialog.dart";
+import "package:gitdone/ui/_widgets/task_card.dart";
+
+/// A widget that displays a single task item in the task list with swipe-to-dismiss functionality.
+class TaskListItem extends StatelessWidget {
+  /// Creates a new instance of [TaskListItem].
+  const TaskListItem({required this.task, super.key});
+
+  /// The task to display.
+  final Task task;
+
+  @override
+  Widget build(final BuildContext context) {
+    final _ItemConfig config = task.state == IssueState.open.value
+        ? (icon: Icons.done, label: "Mark as done", newState: IssueState.closed)
+        : (icon: Icons.undo, label: "Reopen task", newState: IssueState.open);
+
+    return Dismissible(
+      key: ValueKey(task.toString()),
+      direction: DismissDirection.startToEnd,
+      background: Container(
+        color: AppColor.colorScheme.primary,
+        alignment: Alignment.centerLeft,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Row(
+          children: [
+            Icon(config.icon, color: Colors.white),
+            const SizedBox(width: 8),
+            Text(config.label, style: const TextStyle(color: Colors.white)),
+          ],
+        ),
+      ),
+      confirmDismiss: (final direction) async {
+        bool confirmed = false;
+        await showMarkTaskConfirmationDialog(
+          context: context,
+          currentTaskState: task.state,
+          onConfirm: () => confirmed = true,
+        );
+        return confirmed;
+      },
+      onDismissed: (final direction) =>
+          TaskHandler().updateIssueState(task, config.newState),
+      child: TaskCard(task: task),
+    );
+  }
+
+  @override
+  void debugFillProperties(final DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Task>("task", task));
+  }
+}
+
+typedef _ItemConfig = ({IconData icon, String label, IssueState newState});

--- a/lib/ui/task_list/task_list_view.dart
+++ b/lib/ui/task_list/task_list_view.dart
@@ -43,7 +43,7 @@ class _TaskListViewState extends State<TaskListView> {
   @override
   Widget build(final BuildContext context) => Scaffold(
     body: Padding(
-      padding: const EdgeInsets.only(top: 16),
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       child: ChangeNotifierProvider(
         create: (_) => TaskListViewModel()..loadTasks(),
         child: Consumer<TaskListViewModel>(
@@ -51,6 +51,7 @@ class _TaskListViewState extends State<TaskListView> {
             _getFilterItems();
             _getSortItems();
             return Column(
+              spacing: 8,
               children: [
                 _buildSearchField(model),
                 _buildFilterRow(model),
@@ -68,45 +69,39 @@ class _TaskListViewState extends State<TaskListView> {
     floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
   );
 
-  Widget _buildSearchField(final TaskListViewModel model) => Padding(
-    padding: const EdgeInsets.symmetric(horizontal: 16),
-    child: TextField(
-      decoration: const InputDecoration(
-        border: OutlineInputBorder(),
-        labelText: "Search",
-        prefixIcon: Icon(Icons.search),
-      ),
-      onChanged: model.updateSearchQuery,
+  Widget _buildSearchField(final TaskListViewModel model) => TextField(
+    decoration: const InputDecoration(
+      border: OutlineInputBorder(),
+      labelText: "Search",
+      prefixIcon: Icon(Icons.search),
     ),
+    onChanged: model.updateSearchQuery,
   );
 
-  Widget _buildFilterRow(final TaskListViewModel model) => Padding(
-    padding: const EdgeInsets.only(right: 16, left: 16),
-    child: Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        _buildFilterChipDropdown(
-          items: _filterItems!,
-          initialLabel: "Filter",
-          onUpdate: model.updateFilter,
+  Widget _buildFilterRow(final TaskListViewModel model) => Row(
+    mainAxisAlignment: MainAxisAlignment.start,
+    children: [
+      _buildFilterChipDropdown(
+        items: _filterItems!,
+        initialLabel: "Filter",
+        onUpdate: model.updateFilter,
+      ),
+      const SizedBox(width: 8),
+      _buildFilterChipDropdown(
+        items: _sortItems!,
+        initialLabel: "Sort",
+        onUpdate: model.updateSort,
+      ),
+      const SizedBox(width: 8),
+      Consumer<TaskListViewModel>(
+        builder: (final context, final model, _) => _buildFilterChipDropdown(
+          items: model.labelFilterChipItems,
+          initialLabel: "Labels",
+          allowMultipleSelection: true,
+          onUpdate: model.updateLabels,
         ),
-        const SizedBox(width: 8),
-        _buildFilterChipDropdown(
-          items: _sortItems!,
-          initialLabel: "Sort",
-          onUpdate: model.updateSort,
-        ),
-        const SizedBox(width: 8),
-        Consumer<TaskListViewModel>(
-          builder: (final context, final model, _) => _buildFilterChipDropdown(
-            items: model.labelFilterChipItems,
-            initialLabel: "Labels",
-            allowMultipleSelection: true,
-            onUpdate: model.updateLabels,
-          ),
-        ),
-      ],
-    ),
+      ),
+    ],
   );
 
   Widget _buildFilterChipDropdown({

--- a/lib/ui/task_list/task_list_view.dart
+++ b/lib/ui/task_list/task_list_view.dart
@@ -1,9 +1,7 @@
 import "package:flutter/material.dart";
-import "package:gitdone/core/task_handler.dart";
-import "package:gitdone/core/theme/app_color.dart";
 import "package:gitdone/ui/_widgets/filter_chip/filter_chip_dropdown.dart";
 import "package:gitdone/ui/_widgets/filter_chip/filter_chip_item.dart";
-import "package:gitdone/ui/_widgets/task_card.dart";
+import "package:gitdone/ui/task_list/_widgets/task_list_item.dart";
 import "package:gitdone/ui/task_list/task_list_view_model.dart";
 import "package:provider/provider.dart";
 
@@ -144,32 +142,7 @@ class _TaskListViewState extends State<TaskListView> {
           shrinkWrap: true,
           physics: const AlwaysScrollableScrollPhysics(),
           children: model.tasks
-              .map(
-                (final task) => task.state == IssueState.open.value
-                    ? Dismissible(
-                        key: ValueKey(task.issueNumber),
-                        direction: DismissDirection.startToEnd,
-                        background: Container(
-                          color: AppColor.colorScheme.primary,
-                          alignment: Alignment.centerRight,
-                          padding: const EdgeInsets.symmetric(horizontal: 20),
-                          child: const Row(
-                            children: [
-                              Text("Mark as done"),
-                              Icon(Icons.done, color: Colors.white),
-                            ],
-                          ),
-                        ),
-                        onDismissed: (_) {
-                          TaskHandler().updateIssueState(
-                            task,
-                            IssueState.closed,
-                          );
-                        },
-                        child: TaskCard(task: task),
-                      )
-                    : TaskCard(task: task),
-              )
+              .map((final task) => TaskListItem(task: task))
               .toList(),
         ),
       ),

--- a/lib/ui/task_list/task_list_view.dart
+++ b/lib/ui/task_list/task_list_view.dart
@@ -137,7 +137,12 @@ class _TaskListViewState extends State<TaskListView> {
           shrinkWrap: true,
           physics: const AlwaysScrollableScrollPhysics(),
           children: model.tasks
-              .map((final task) => TaskListItem(task: task))
+              .map(
+                (final task) => TaskListItem(
+                  task: task,
+                  key: ValueKey("${task.slug}#${task.issueNumber}"),
+                ),
+              )
               .toList(),
         ),
       ),

--- a/lib/ui/task_list/task_list_view_model.dart
+++ b/lib/ui/task_list/task_list_view_model.dart
@@ -159,9 +159,13 @@ class TaskListViewModel extends ChangeNotifier {
     final String filter,
   ) {
     if (filter == _filterCompleted) {
-      return tasks.where((final task) => task.closedAt != null).toList();
+      return tasks
+          .where((final task) => task.state == IssueState.closed.value)
+          .toList();
     } else if (filter == _filterPending) {
-      return tasks.where((final task) => task.closedAt == null).toList();
+      return tasks
+          .where((final task) => task.state == IssueState.open.value)
+          .toList();
     }
     return tasks;
   }


### PR DESCRIPTION
This pull request introduces a new confirmation dialog flow for marking tasks as done or reopening them, adds a user setting to control this confirmation, and refactors related UI components for improved maintainability and consistency. The changes also include some UI layout tweaks and code clean-up.

**Confirmation dialog and settings:**

* Added a reusable confirmation dialog (`showMarkTaskConfirmationDialog` in `mark_task_confirmation_dialog.dart`) that asks users to confirm before marking a task as done or reopening it, with a "Don't ask me again" option. This dialog is now used in both the task list and task details views. [[1]](diffhunk://#diff-15a3c9588f2dd0fa26e2f6188991c0bcce06259edd203416a16697798e8dcbafR1-R77) [[2]](diffhunk://#diff-f22e980c68e6f452e297b730c29dd792808a01f54e996d7f12035db35fb39c07R1-R64) [[3]](diffhunk://#diff-4f64934fa75df657904672809a2f4615bc21f70aa14b298f31b64049fd18f16dR1-R53)
* Introduced a new persistent setting (`showMarkTaskStateConfirmation` in `SettingsHandler`) that controls whether the confirmation dialog is shown. This setting is toggleable from the new "General Settings" section in the app settings. [[1]](diffhunk://#diff-aa89444ba7381511a1b511145929bdaeba644a77eeb68106f6188bf95f458b41R12-R23) [[2]](diffhunk://#diff-aa89444ba7381511a1b511145929bdaeba644a77eeb68106f6188bf95f458b41R97-R110) [[3]](diffhunk://#diff-fe0982f2ae9e565aadc2ffd662b9b97e4db06bff425420251405aa982cb529f6R1-R17) [[4]](diffhunk://#diff-cb83aa4b6d587d9d28adcdf50220453af8f5338c3550f691dafce2bb194d8acdR1-R23) [[5]](diffhunk://#diff-3a0ca2cca2a0ece026cb5b41d69f6247a9407f8112973f84afc78c81c7fbb5dfR5) [[6]](diffhunk://#diff-3a0ca2cca2a0ece026cb5b41d69f6247a9407f8112973f84afc78c81c7fbb5dfR25)

**UI and code refactoring:**

* Refactored the floating action buttons in the task details view into a dedicated widget (`TaskDetailsFloatingActionButton`), and replaced the old implementation. [[1]](diffhunk://#diff-4f64934fa75df657904672809a2f4615bc21f70aa14b298f31b64049fd18f16dR1-R53) [[2]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370L4-R10) [[3]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370L56-R58) [[4]](diffhunk://#diff-5da8a48a71f07252f0e2035bbe3f79eb278615fed4b951ce371444236acd7370L101-L121)
* Refactored the task list to use a new `TaskListItem` widget, centralizing the swipe-to-dismiss logic and confirmation dialog handling. [[1]](diffhunk://#diff-f22e980c68e6f452e297b730c29dd792808a01f54e996d7f12035db35fb39c07R1-R64) [[2]](diffhunk://#diff-93b352a985be1490c41e83b5d0d3243d17c9ed18610218f093a6c5a9c83f92fcL2-R4) [[3]](diffhunk://#diff-93b352a985be1490c41e83b5d0d3243d17c9ed18610218f093a6c5a9c83f92fcL147-R140)
* Updated the general UI layout for task cards and the task list for improved consistency and spacing. [[1]](diffhunk://#diff-d080f446d71b67b9f99b98668925937e9a0800edff3028e44c7a1689ec67d690L29-R34) [[2]](diffhunk://#diff-d080f446d71b67b9f99b98668925937e9a0800edff3028e44c7a1689ec67d690L56) [[3]](diffhunk://#diff-93b352a985be1490c41e83b5d0d3243d17c9ed18610218f093a6c5a9c83f92fcL48-R54) [[4]](diffhunk://#diff-93b352a985be1490c41e83b5d0d3243d17c9ed18610218f093a6c5a9c83f92fcL73-R81) [[5]](diffhunk://#diff-93b352a985be1490c41e83b5d0d3243d17c9ed18610218f093a6c5a9c83f92fcL111)

**Improvements to confirmation dialog widget:**

* Improved the `ConfirmDialog` API to return a `bool?` indicating the user's action, clarified the button roles, and adjusted navigation behavior for better integration with the new dialog flow. [[1]](diffhunk://#diff-10ab540d59feb7f910d53209adf4e1cdbe1d06d16ebe6f60b9f314a172d91005L36-R55) [[2]](diffhunk://#diff-10ab540d59feb7f910d53209adf4e1cdbe1d06d16ebe6f60b9f314a172d91005L61-R64)

Closes #262