### PR TITLE
🐛 Add ignored vulnerabilities for VitePress dependency

### DIFF
--- a/docs/osv-scanner.toml
+++ b/docs/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GHSA-g7r4-m6w7-qqqr"
+reason = "VitePress v1 currently depends on vulnerable esbuild; tracked until VitePress v2 upgrade is available."


### PR DESCRIPTION
This pull request adds a new ignored vulnerability to the `osv-scanner.toml` configuration, documenting the reason for ignoring it until a dependency can be upgraded. No other changes are included.

- [`docs/osv-scanner.toml`](diffhunk://#diff-35d55ade379936706f0677bc7b09cf0b527923835bd6ffde7380c00543daf775R1-R3): Added an entry to ignore vulnerability `GHSA-g7r4-m6w7-qqqr`, with a note explaining it's due to a dependency in VitePress v1 and will be tracked until an upgrade to v2 is available.